### PR TITLE
Reserialize floats exactly as read

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
@@ -10,12 +10,30 @@ final class FloatTomlPrimitive extends AbstractTomlPrimitive<Double> {
 
     private static final DecimalFormat DF = new DecimalFormat("0.###############");
 
+    private static @NotNull String autoChars(double value) {
+        if (value == Double.POSITIVE_INFINITY) return "inf";
+        if (value == Double.NEGATIVE_INFINITY) return "-inf";
+        if (Double.isNaN(value)) return "nan";
+        if ((value % 1) == 0) {
+            if (Double.doubleToLongBits(value) == -9223372036854775808L) return "-0";
+            return Long.toString((long) value);
+        }
+        return DF.format(value);
+    }
+
     //
 
     private final double value;
+    private final String chars;
+
+    /** Called by {@code UnsafePrimitives} in {@code jtoml-internals} */
+    public FloatTomlPrimitive(double value, @NotNull String chars) {
+        this.value = value;
+        this.chars = chars;
+    }
 
     public FloatTomlPrimitive(double value) {
-        this.value = value;
+        this(value, autoChars(value));
     }
 
     //
@@ -32,14 +50,7 @@ final class FloatTomlPrimitive extends AbstractTomlPrimitive<Double> {
 
     @Override
     public @NotNull String asString() {
-        if (this.value == Double.POSITIVE_INFINITY) return "inf";
-        if (this.value == Double.NEGATIVE_INFINITY) return "-inf";
-        if (Double.isNaN(this.value)) return "nan";
-        if ((this.value % 1) == 0) {
-            if (Double.doubleToLongBits(this.value) == -9223372036854775808L) return "-0";
-            return Long.toString((long) this.value);
-        }
-        return DF.format(this.value);
+        return this.chars;
     }
 
     @Override

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
@@ -9,6 +9,7 @@ import io.github.wasabithumb.jtoml.option.JTomlOption;
 import io.github.wasabithumb.jtoml.option.JTomlOptions;
 import io.github.wasabithumb.jtoml.value.FlaggedTomlValue;
 import io.github.wasabithumb.jtoml.value.TomlValue;
+import io.github.wasabithumb.jtoml.value.UnsafePrimitives;
 import io.github.wasabithumb.jtoml.value.array.TomlArray;
 import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
@@ -455,9 +456,10 @@ public class ExpressionReader implements Closeable {
             char c1 = str.charAt(head + 1);
             char c2 = str.charAt(head + 2);
             if (c0 == 'i' && c1 == 'n' && c2 == 'f') {
-                return TomlPrimitive.of(negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
+                return negative ? UnsafePrimitives.createFloat(Double.NEGATIVE_INFINITY, "-inf") :
+                        UnsafePrimitives.createFloat(Double.POSITIVE_INFINITY, "inf");
             } else if (c0 == 'n' && c1 == 'a' && c2 == 'n') {
-                return TomlPrimitive.of(Double.NaN);
+                return UnsafePrimitives.createFloat(Double.NaN, "nan");
             }
         }
 
@@ -567,7 +569,7 @@ public class ExpressionReader implements Closeable {
             d = ((double) ip) + frac;
         }
         if (negative) d = -d;
-        return TomlPrimitive.of(d);
+        return UnsafePrimitives.createFloat(d, str.toString());
     }
 
     private @NotNull TomlPrimitive parseDateTime(@NotNull CharSequence str) throws TomlException, DateTimeException {

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/io/TableWriter.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/io/TableWriter.java
@@ -176,8 +176,14 @@ public final class TableWriter implements Closeable {
             this.out.put(v);
 
             // Ensure that we aren't writing a float as an integer
-            if (v.indexOf('.') == -1 && v.indexOf('e') == -1 && !v.contains("inf") && !v.contains("nan"))
+            if (v.indexOf('.') == -1 &&
+                    v.indexOf('e') == -1 &&
+                    v.indexOf('E') == -1 &&
+                    !v.contains("inf") &&
+                    !v.contains("nan")
+            ) {
                 this.out.put(".0");
+            }
         } else {
             this.out.put(value.asString());
         }

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/value/UnsafePrimitives.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/value/UnsafePrimitives.java
@@ -1,0 +1,54 @@
+package io.github.wasabithumb.jtoml.value;
+
+import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApiStatus.Experimental
+public final class UnsafePrimitives {
+
+    private static final Constructor<?> FLOAT_WITH_CHARS;
+    static {
+        Class<?> cls;
+        Constructor<?> con = null;
+        try {
+            cls = Class.forName("io.github.wasabithumb.jtoml.value.primitive.FloatTomlPrimitive");
+            con = cls.getDeclaredConstructor(Double.TYPE, String.class);
+            con.setAccessible(true);
+        } catch (ReflectiveOperationException | SecurityException e) {
+            Logger.getLogger("jtoml")
+                    .log(Level.WARNING, "Failed to access float constructor (please report this)", e);
+        }
+        FLOAT_WITH_CHARS = con;
+    }
+
+    //
+
+    @Contract("_, _ -> new")
+    public static @NotNull TomlPrimitive createFloat(double v, @NotNull String chars) {
+        if (FLOAT_WITH_CHARS == null) return TomlPrimitive.of(v);
+        TomlPrimitive ret;
+        try {
+            ret = (TomlPrimitive) FLOAT_WITH_CHARS.newInstance(v, chars);
+        } catch (InvocationTargetException | ExceptionInInitializerError e) {
+            Throwable cause = e.getCause();
+            if (cause == null) cause = e;
+            if (cause instanceof RuntimeException) throw ((RuntimeException) cause);
+            throw new AssertionError("Unexpected error in constructor/initializer", e);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unexpected reflection error", e);
+        }
+        return ret;
+    }
+
+    //
+
+    private UnsafePrimitives() { }
+
+}


### PR DESCRIPTION
Floats read by JToml will now retain the string from which the float was originally parsed from. This regains information that would be otherwise lost, and makes JToml reserialization a "stable" operation (in terms of values; keys are still sorted lexicographically). Floats defined through the API will immediately compute a valid string representation.