### PR TITLE
Properly disallow invalid years in date-times

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
@@ -3,6 +3,7 @@ package io.github.wasabithumb.jtoml;
 import io.github.wasabithumb.jtoml.document.TomlDocument;
 import io.github.wasabithumb.jtoml.except.TomlException;
 import io.github.wasabithumb.jtoml.except.TomlIOException;
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import io.github.wasabithumb.jtoml.option.JTomlOptions;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
 import org.jetbrains.annotations.ApiStatus;
@@ -69,17 +70,17 @@ public interface JToml {
     //
 
     /** Converts a TOML table to a string */
-    @NotNull String writeToString(@NotNull TomlTable table);
+    @NotNull String writeToString(@NotNull TomlTable table) throws TomlValueException;
 
     /** Writes a TOML table to a stream */
-    void write(@NotNull OutputStream out, @NotNull TomlTable table) throws TomlIOException;
+    void write(@NotNull OutputStream out, @NotNull TomlTable table) throws TomlException;
 
     /** Writes a TOML table to a writer */
     @ApiStatus.AvailableSince("0.3.0")
-    void write(@NotNull Writer writer, @NotNull TomlTable table) throws TomlIOException;
+    void write(@NotNull Writer writer, @NotNull TomlTable table) throws TomlException;
 
     /** Writes a TOML table to a file */
-    default void write(@NotNull Path file, @NotNull TomlTable table) throws TomlIOException {
+    default void write(@NotNull Path file, @NotNull TomlTable table) throws TomlException {
         try (OutputStream os = Files.newOutputStream(
                 file,
                 StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING
@@ -91,7 +92,7 @@ public interface JToml {
     }
 
     /** Writes a TOML table to a file */
-    default void write(@NotNull File file, @NotNull TomlTable table) throws TomlIOException {
+    default void write(@NotNull File file, @NotNull TomlTable table) throws TomlException {
         this.write(file.toPath(), table);
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/except/TomlValueException.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/except/TomlValueException.java
@@ -1,0 +1,37 @@
+package io.github.wasabithumb.jtoml.except;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+
+/**
+ * <p>
+ *     Thrown when attempting to convert a wider type into a narrower TOML
+ *     primitive. This cannot be thrown for parsing; only for serialization/writing
+ *     and through API usage.
+ * </p>
+ * <p>
+ *     This is currently only used for date-times, specifically when trying to
+ *     wrap a Java {@link java.time.OffsetDateTime OffsetDateTime}/{@link java.time.LocalDateTime LocalDateTime}/
+ *     {@link java.time.LocalDate LocalDate} which has a {@link java.time.LocalDate#getYear() year} less than
+ *     0 or greater than 9999.
+ * </p>
+ * @since 0.4.0
+ */
+public final class TomlValueException extends TomlException {
+
+    public static void checkDate(@NotNull TemporalAccessor date) {
+        final int year = date.get(ChronoField.YEAR);
+        if (0 <= year && year <= 9999) return;
+        throw new TomlValueException("Date-time " + date + " has illegal year: " + year);
+    }
+
+    //
+
+    public TomlValueException(@NotNull String message) {
+        super(message);
+    }
+
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTimeTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTimeTomlPrimitive.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.value.primitive;
 
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,7 @@ final class LocalDateTimeTomlPrimitive extends AbstractTomlPrimitive<LocalDateTi
     private final ZoneOffset offset;
 
     public LocalDateTimeTomlPrimitive(@NotNull LocalDateTime value, @NotNull ZoneOffset offset) {
+        TomlValueException.checkDate(value);
         this.value = value;
         this.offset = offset;
     }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTomlPrimitive.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.value.primitive;
 
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,7 @@ final class LocalDateTomlPrimitive extends AbstractTomlPrimitive<LocalDate> {
     private final ZoneOffset offset;
 
     public LocalDateTomlPrimitive(@NotNull LocalDate value, @NotNull ZoneOffset offset) {
+        TomlValueException.checkDate(value);
         this.value = value;
         this.offset = offset;
     }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/OffsetDateTimeTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/OffsetDateTimeTomlPrimitive.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.value.primitive;
 
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,6 +12,7 @@ final class OffsetDateTimeTomlPrimitive extends AbstractTomlPrimitive<OffsetDate
     private final OffsetDateTime value;
 
     public OffsetDateTimeTomlPrimitive(@NotNull OffsetDateTime value) {
+        TomlValueException.checkDate(value);
         this.value = value;
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.value.primitive;
 
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import io.github.wasabithumb.jtoml.value.TomlValue;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -44,12 +45,12 @@ public interface TomlPrimitive extends TomlValue {
     }
 
     @Contract("null -> fail; !null -> new")
-    static @NotNull TomlPrimitive of(OffsetDateTime value) {
+    static @NotNull TomlPrimitive of(OffsetDateTime value) throws TomlValueException {
         return new OffsetDateTimeTomlPrimitive(Objects.requireNonNull(value));
     }
 
     @Contract("null, _ -> fail; !null, _ -> new")
-    static @NotNull TomlPrimitive of(LocalDateTime value, @Nullable ZoneOffset offset) {
+    static @NotNull TomlPrimitive of(LocalDateTime value, @Nullable ZoneOffset offset) throws TomlValueException {
         return new LocalDateTimeTomlPrimitive(
                 Objects.requireNonNull(value),
                 (offset == null) ? ZoneOffset.UTC : offset
@@ -57,12 +58,12 @@ public interface TomlPrimitive extends TomlValue {
     }
 
     @Contract("null -> fail; !null -> new")
-    static @NotNull TomlPrimitive of(LocalDateTime value) {
+    static @NotNull TomlPrimitive of(LocalDateTime value) throws TomlValueException {
         return of(value, null);
     }
 
     @Contract("null, _ -> fail; !null, _ -> new")
-    static @NotNull TomlPrimitive of(LocalDate value, @Nullable ZoneOffset offset) {
+    static @NotNull TomlPrimitive of(LocalDate value, @Nullable ZoneOffset offset) throws TomlValueException {
         return new LocalDateTomlPrimitive(
                 Objects.requireNonNull(value),
                 (offset == null) ? ZoneOffset.UTC : offset
@@ -70,7 +71,7 @@ public interface TomlPrimitive extends TomlValue {
     }
 
     @Contract("null -> fail; !null -> new")
-    static @NotNull TomlPrimitive of(LocalDate value) {
+    static @NotNull TomlPrimitive of(LocalDate value) throws TomlValueException {
         return of(value, null);
     }
 

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
@@ -170,8 +170,11 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<B
         populateTable(document, node);
         try {
             this.jtoml.write(writer, document);
-        } catch (final TomlIOException ex) {
-            throw new ConfigurateException("Exception writing TOML document", ex.getCause());
+        } catch (final TomlException ex) {
+            throw new ConfigurateException(
+                    "Exception writing TOML document",
+                    (ex instanceof TomlIOException) ? ex.getCause() : ex
+            );
         }
     }
 

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -11,6 +11,10 @@ import io.github.wasabithumb.jtoml.value.table.TomlTable;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -144,6 +148,14 @@ public final class ReflectTomlSerializer<T extends TomlSerializable> implements 
             }
         } else if (ft.isAssignableFrom(String.class)) {
             return value.asPrimitive().asString();
+        } else if (ft.isAssignableFrom(OffsetDateTime.class)) {
+            return value.asPrimitive().asOffsetDateTime();
+        } else if (ft.isAssignableFrom(LocalDateTime.class)) {
+            return value.asPrimitive().asLocalDateTime();
+        } else if (ft.isAssignableFrom(LocalDate.class)) {
+            return value.asPrimitive().asLocalDate();
+        } else if (ft.isAssignableFrom(LocalTime.class)) {
+            return value.asPrimitive().asLocalTime();
         } else if (ft.isAssignableFrom(Map.class)) {
             Map<String, Object> map = new HashMap<>();
             if (!value.isTable()) throw new IllegalStateException("Cannot unpack non-table value (" + value + ")");
@@ -216,6 +228,14 @@ public final class ReflectTomlSerializer<T extends TomlSerializable> implements 
             }
         } else if (o instanceof Character) {
             return TomlPrimitive.of(Character.toString((Character) o));
+        } else if (o instanceof OffsetDateTime) {
+            return TomlPrimitive.of((OffsetDateTime) o);
+        } else if (o instanceof LocalDateTime) {
+            return TomlPrimitive.of((LocalDateTime) o);
+        } else if (o instanceof LocalDate) {
+            return TomlPrimitive.of((LocalDate) o);
+        } else if (o instanceof LocalTime) {
+            return TomlPrimitive.of((LocalTime) o);
         } else if (o instanceof Map) {
             Map<?, ?> map = (Map<?, ?>) o;
             TomlTable ret = TomlTable.create();

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -2,8 +2,10 @@ package io.github.wasabithumb.jtoml;
 
 import io.github.wasabithumb.jtoml.document.TomlDocument;
 import io.github.wasabithumb.jtoml.except.TomlException;
+import io.github.wasabithumb.jtoml.except.TomlValueException;
 import io.github.wasabithumb.jtoml.except.parse.TomlParseException;
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.pojo.SimpleTable;
 import io.github.wasabithumb.jtoml.test.TestSpec;
 import io.github.wasabithumb.jtoml.test.TestSpecs;
 import io.github.wasabithumb.jtoml.value.TomlValue;
@@ -19,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -55,6 +58,22 @@ class JTomlTest {
                 TOML.write(sw, document);
             }
         });
+    }
+
+    @Test
+    void reflect() {
+        SimpleTable original = SimpleTable.create();
+        TomlTable toml = TOML.deserialize(SimpleTable.class, original);
+        System.out.println(TOML.writeToString(toml));
+        SimpleTable out = TOML.serialize(SimpleTable.class, toml);
+        assertEquals(original, out);
+    }
+
+    @Test
+    void badDateTime() {
+        SimpleTable table = SimpleTable.create();
+        table.localDate = LocalDate.of(-1, 7, 16); // year -1
+        assertThrows(TomlValueException.class, () -> TOML.deserialize(SimpleTable.class, table));
     }
 
     //

--- a/src/test/java/io/github/wasabithumb/jtoml/pojo/SimpleTable.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/pojo/SimpleTable.java
@@ -1,0 +1,67 @@
+package io.github.wasabithumb.jtoml.pojo;
+
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public final class SimpleTable implements TomlSerializable {
+
+    public static SimpleTable create() {
+        SimpleTable ret = new SimpleTable();
+        ret.text = "hello\njtoml ❤";
+        ret.integer = 1234;
+        ret.decimal = 56.789;
+        ret.localDate = LocalDate.of(1996, 1, 23);
+        ret.localTime = LocalTime.of(16, 50);
+        ret.localDateTime = LocalDateTime.now();
+        ret.offsetDateTime = OffsetDateTime.now();
+        return ret;
+    }
+
+    //
+
+    public String text;
+    public long integer;
+    public double decimal;
+    public LocalDate localDate;
+    public LocalTime localTime;
+    public LocalDateTime localDateTime;
+    public OffsetDateTime offsetDateTime;
+    
+    SimpleTable() { }
+
+    //
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                this.text,
+                this.integer,
+                this.decimal,
+                this.localDate,
+                this.localTime,
+                this.localDateTime,
+                this.offsetDateTime
+        );
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof SimpleTable)) return false;
+        SimpleTable other = (SimpleTable) obj;
+
+        return Objects.equals(this.text, other.text) &&
+                this.integer == other.integer &&
+                this.decimal == other.decimal &&
+                Objects.equals(this.localDate, other.localDate) &&
+                Objects.equals(this.localTime, other.localTime) &&
+                Objects.equals(this.localDateTime, other.localDateTime) &&
+                Objects.equals(this.offsetDateTime, other.offsetDateTime);
+    }
+
+}


### PR DESCRIPTION
Attempting to assign a Java Temporal with year outside of the range 0 to 9999 will now raise ``TomlValueException``. This is the only exception other than ``TomlIOException`` which should reasonably throw when writing, hence necessitating a small update to some method signatures and try/catch blocks.