### PR TITLE
Replace TomlTable implementation with tree

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
@@ -83,6 +83,16 @@ public interface TomlTable extends TomlValue {
     boolean contains(@NotNull TomlKey key);
 
     /**
+     * Returns true if the given key has a mapping within this table.
+     * This will return true for keys mapped to tables, including empty tables.
+     * The key is parsed as specified by {@link TomlKey#parse(CharSequence)}.
+     * @see #contains(TomlKey)
+     */
+    default boolean contains(@NotNull CharSequence key) {
+        return this.contains(TomlKey.parse(key));
+    }
+
+    /**
      * Gets the value mapped to the given key, or null
      * if no entry exists.
      */

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
@@ -17,14 +17,22 @@ import java.util.Set;
 @ApiStatus.NonExtendable
 public interface TomlTable extends TomlValue {
 
+    /**
+     * Creates an empty table
+     */
     @Contract("-> new")
     static @NotNull TomlTable create() {
         return new TomlTableImpl();
     }
 
+    /**
+     * Creates a new table which contains the same
+     * tree as the given table
+     */
     @Contract("_ -> new")
     static @NotNull TomlTable copyOf(@NotNull TomlTable other) {
         TomlTableImpl ret = new TomlTableImpl();
+        // TODO: this cast will be bad soon
         ret.putAll((TomlTableImpl) other);
         return ret;
     }
@@ -77,72 +85,204 @@ public interface TomlTable extends TomlValue {
      */
     boolean contains(@NotNull TomlKey key);
 
+    /**
+     * Gets the value mapped to the given key, or null
+     * if no entry exists.
+     */
     @Nullable TomlValue get(@NotNull TomlKey key);
 
+    /**
+     * Gets the value mapped to the given key, or null
+     * if no entry exists. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @see #get(TomlKey)
+     */
     default @Nullable TomlValue get(@NotNull CharSequence key) {
         return this.get(TomlKey.parse(key));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     @Nullable TomlValue put(@NotNull TomlKey key, @NotNull TomlValue value);
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, TomlValue)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, @NotNull TomlValue value) {
         return this.put(TomlKey.parse(key), value);
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, @NotNull String value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, boolean value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, long value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, int value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, double value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     */
     default @Nullable TomlValue put(@NotNull TomlKey key, float value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, String)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, @NotNull String value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, boolean)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, boolean value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, long)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, long value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, int)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, int value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, double)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, double value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Updates the value mapped to the given key, creating a
+     * new entry if one does not exist.
+     * The value is wrapped into a {@link TomlPrimitive}
+     * before being placed into the map. The key is parsed
+     * as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null the entry was newly created
+     * @see #put(TomlKey, float)
+     */
     default @Nullable TomlValue put(@NotNull CharSequence key, float value) {
         return this.put(key, TomlPrimitive.of(value));
     }
 
+    /**
+     * Removes the entry associated with the given key.
+     * @return The value previously mapped to the given key, or null if no entry exists.
+     */
     @Nullable TomlValue remove(@NotNull TomlKey key);
 
+    /**
+     * Removes the entry associated with the given key.
+     * The key is parsed as specified by {@link TomlKey#parse(CharSequence)}.
+     * @return The value previously mapped to the given key, or null if no entry exists.
+     * @see #remove(TomlKey)
+     */
     default @Nullable TomlValue remove(@NotNull String key) {
         return this.remove(TomlKey.parse(key));
     }
 
+    /**
+     * Creates a new map which contains a flattened view of this
+     * table
+     */
     @Contract("-> new")
     default @NotNull Map<TomlKey, TomlValue> toMap() {
         Set<TomlKey> keys = this.keys();

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTable.java
@@ -26,15 +26,12 @@ public interface TomlTable extends TomlValue {
     }
 
     /**
-     * Creates a new table which contains the same
-     * tree as the given table
+     * Creates a new table which contains a
+     * deep copy of the given table
      */
     @Contract("_ -> new")
     static @NotNull TomlTable copyOf(@NotNull TomlTable other) {
-        TomlTableImpl ret = new TomlTableImpl();
-        // TODO: this cast will be bad soon
-        ret.putAll((TomlTableImpl) other);
-        return ret;
+        return TomlTableImpl.copyOf((TomlTableImpl) other);
     }
 
     //
@@ -64,14 +61,14 @@ public interface TomlTable extends TomlValue {
     void clear();
 
     /**
-     * Reports the keys in this table
-     * @param deep If true, children will be traversed (as in {@link #keys()}). Otherwise,
-     *             the top-level keys are reported; each having a length of 1
+     * Reports the keys in this table in lexicographical order.
+     * @param deep If true, children will be traversed (as in {@link #keys()}). Otherwise only
+     *             the top-level keys are reported, each having a length of 1.
      */
     @NotNull @Unmodifiable Set<TomlKey> keys(boolean deep);
 
     /**
-     * Reports the keys present in this table recursively.
+     * Reports the keys present in this table recursively in lexicographical order.
      * Keys that map to tables are not included.
      * @see #keys(boolean)
      */
@@ -281,7 +278,7 @@ public interface TomlTable extends TomlValue {
 
     /**
      * Creates a new map which contains a flattened view of this
-     * table
+     * table. The resulting table is ordered arbitrarily.
      */
     @Contract("-> new")
     default @NotNull Map<TomlKey, TomlValue> toMap() {

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
@@ -156,10 +156,17 @@ final class TomlTableBranch implements TomlTableNode {
             parent.modifyEntryCount(mod);
     }
 
-    private void addParent(@NotNull TomlTableBranch parent) {
-        if (parent.equals(this) || parent.parents.contains(this)) {
-            throw new IllegalStateException("Attempt to create recursive table relationship");
+    private boolean isInHierarchy(@NotNull TomlTableBranch subject) {
+        if (this.equals(subject)) return true;
+        for (TomlTableBranch parent : this.parents) {
+            if (parent.isInHierarchy(subject)) return true;
         }
+        return false;
+    }
+
+    private void addParent(@NotNull TomlTableBranch parent) {
+        if (parent.isInHierarchy(this))
+            throw new IllegalStateException("Attempt to create recursive table relationship");
         this.parents.add(parent);
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
@@ -166,7 +166,7 @@ final class TomlTableBranch implements TomlTableNode {
 
     private void addParent(@NotNull TomlTableBranch parent) {
         if (parent.isInHierarchy(this))
-            throw new IllegalStateException("Attempt to create recursive table relationship");
+            throw new IllegalStateException("Attempt to create circular table relationship");
         this.parents.add(parent);
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.value.table;
 
+import io.github.wasabithumb.jtoml.value.TomlValue;
 import org.jetbrains.annotations.*;
 
 import java.util.*;
@@ -41,6 +42,7 @@ final class TomlTableBranch implements TomlTableNode {
     private String[] labels;
     private TomlTableNode[] nodes;
     private int entryCount;
+    TomlValue attachedValue;
 
     private TomlTableBranch(int capacity) {
         this.parents = Collections.newSetFromMap(new WeakHashMap<>());
@@ -49,6 +51,7 @@ final class TomlTableBranch implements TomlTableNode {
         this.labels = new String[capacity];
         this.nodes = new TomlTableNode[capacity];
         this.entryCount = 0;
+        this.attachedValue = null;
     }
 
     TomlTableBranch() {

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
@@ -1,0 +1,221 @@
+package io.github.wasabithumb.jtoml.value.table;
+
+import org.jetbrains.annotations.*;
+
+import java.util.*;
+
+@ApiStatus.Internal
+final class TomlTableBranch implements TomlTableNode {
+
+    @Contract("_ -> new")
+    public static @NotNull TomlTableBranch copyOf(@NotNull TomlTableBranch branch) {
+        return copyOf(branch, null);
+    }
+
+    @Contract("_, _ -> new")
+    private static @NotNull TomlTableBranch copyOf(@NotNull TomlTableBranch branch, @Nullable TomlTableBranch parent) {
+        TomlTableBranch ret = new TomlTableBranch(branch.capacity);
+        ret.len = branch.len;
+        ret.entryCount = branch.entryCount;
+        System.arraycopy(branch.labels, 0, ret.labels, 0, branch.len);
+
+        TomlTableNode next;
+        for (int i=0; i < branch.len; i++) {
+            next = branch.nodes[i];
+            if (next.isBranch())
+                next = TomlTableBranch.copyOf(next.asBranch(), ret);
+            ret.nodes[i] = next;
+        }
+
+        if (parent != null)
+            ret.parents.add(parent);
+
+        return ret;
+    }
+
+    //
+
+    private final Set<TomlTableBranch> parents;
+    private int capacity;
+    private int len;
+    private String[] labels;
+    private TomlTableNode[] nodes;
+    private int entryCount;
+
+    private TomlTableBranch(int capacity) {
+        this.parents = Collections.newSetFromMap(new WeakHashMap<>());
+        this.capacity = capacity;
+        this.len = 0;
+        this.labels = new String[capacity];
+        this.nodes = new TomlTableNode[capacity];
+        this.entryCount = 0;
+    }
+
+    TomlTableBranch() {
+        this(8);
+    }
+
+    //
+
+    /** @implNote This is a shallow listing */
+    public @NotNull @Unmodifiable List<String> keys() {
+        return Collections.unmodifiableList(Arrays.asList(this.labels).subList(0, this.len));
+    }
+
+    /** @implNote This is a shallow count */
+    public int keyCount() {
+        return this.len;
+    }
+
+    public void clear() {
+        this.len = 0;
+        if (this.capacity > 8) this.resize(8);
+        this.modifyEntryCount(-this.entryCount);
+    }
+
+    public @Nullable TomlTableNode get(@NotNull String label) {
+        TomlTableNode next;
+        int cmp;
+        for (int i=0; i < this.len; i++) {
+            next = this.nodes[i];
+            cmp = label.compareTo(this.labels[i]);
+            if (cmp < 0) {
+                break;
+            } else if (cmp == 0) {
+                return next;
+            }
+        }
+        return null;
+    }
+
+    public @Nullable TomlTableNode put(@NotNull String label, @NotNull TomlTableNode node) {
+        int idx = this.len;
+        boolean shift = false;
+
+        if (node.isBranch())
+            node.asBranch().addParent(this);
+
+        TomlTableNode next;
+        int cmp;
+        for (int i=0; i < this.len; i++) {
+            next = this.nodes[i];
+            cmp = label.compareTo(this.labels[i]);
+            if (cmp == 0) {
+                // clobber
+                this.nodes[i] = node;
+                this.modifyEntryCount(node.entryCount() - next.entryCount());
+                return next;
+            } else if (cmp < 0) {
+                // insert
+                idx = i;
+                shift = true;
+                break;
+            }
+        }
+
+        this.ensureSpace();
+        if (shift) {
+            System.arraycopy(this.nodes, idx, this.nodes, idx + 1, this.len - idx);
+            System.arraycopy(this.labels, idx, this.labels, idx + 1, this.len - idx);
+        }
+        this.nodes[idx] = node;
+        this.labels[idx] = label;
+        this.len++;
+        this.modifyEntryCount(node.entryCount());
+        return null;
+    }
+
+    public @Nullable TomlTableNode remove(@NotNull String label) {
+        TomlTableNode next;
+        int cmp;
+        for (int i=0; i < this.len; i++) {
+            next = this.nodes[i];
+            cmp = label.compareTo(this.labels[i]);
+            if (cmp != 0) {
+                if (cmp > 0) break;
+                continue;
+            }
+            if (next.isBranch())
+                next.asBranch().removeParent(this);
+            this.len--;
+            this.modifyEntryCount(-next.entryCount());
+            System.arraycopy(this.nodes, i + 1, this.nodes, i, this.len - i);
+            System.arraycopy(this.labels, i + 1, this.labels, i, this.len - i);
+            this.tryShrink();
+            return next;
+        }
+        return null;
+    }
+
+    private void modifyEntryCount(int mod) {
+        this.entryCount += mod;
+        for (TomlTableBranch parent : this.parents)
+            parent.modifyEntryCount(mod);
+    }
+
+    private void addParent(@NotNull TomlTableBranch parent) {
+        if (parent.equals(this) || parent.parents.contains(this)) {
+            throw new IllegalStateException("Attempt to create recursive table relationship");
+        }
+        this.parents.add(parent);
+    }
+
+    private void removeParent(@NotNull TomlTableBranch parent) {
+        this.parents.remove(parent);
+    }
+
+    private void resize(int tc) {
+        TomlTableNode[] nn = new TomlTableNode[tc];
+        System.arraycopy(this.nodes, 0, nn, 0, this.len);
+
+        String[] nl = new String[tc];
+        System.arraycopy(this.labels, 0, nl, 0, this.len);
+
+        this.capacity = tc;
+        this.nodes = nn;
+        this.labels = nl;
+    }
+
+    private void ensureSpace() {
+        if (this.len < this.capacity) return;
+        this.resize(this.capacity << 1);
+    }
+
+    private void tryShrink() {
+        int tc = this.capacity >> 1;
+        if (this.len > tc) return;
+        this.resize(tc);
+    }
+
+    // START Node Super
+
+    @Override
+    public int entryCount() {
+        return this.entryCount;
+    }
+
+    @Override
+    public boolean isBranch() {
+        return true;
+    }
+
+    @Override
+    @Contract("-> this")
+    public @NotNull TomlTableBranch asBranch() {
+        return this;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return false;
+    }
+
+    @Override
+    @Contract("-> fail")
+    public @NotNull TomlTableLeaf asLeaf() {
+        throw new UnsupportedOperationException();
+    }
+
+    // END Node Super
+
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
@@ -70,6 +70,7 @@ final class TomlTableImpl implements TomlTable {
         TomlTableNode old;
         if (value.isTable()) {
             TomlTableImpl tbl = (TomlTableImpl) value.asTable();
+            tbl.root.attachedValue = value;
             old = r.branch.put(r.label, tbl.root);
         } else {
             TomlTableLeaf leaf = new TomlTableLeaf(value);
@@ -92,7 +93,10 @@ final class TomlTableImpl implements TomlTable {
         if (node.isLeaf()) {
             return node.asLeaf().value();
         } else {
-            return new TomlTableImpl(node.asBranch());
+            TomlTableBranch branch = node.asBranch();
+            TomlValue ret = branch.attachedValue;
+            if (ret != null) return ret;
+            return new TomlTableImpl(branch);
         }
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
@@ -100,8 +100,10 @@ final class TomlTableImpl implements TomlTable {
         }
     }
 
-    @Contract("_, true -> !null")
-    private @Nullable Resolution resolve(@NotNull TomlKey key, boolean create) {
+    @Contract("null, _ -> fail; _, true -> !null")
+    private @Nullable Resolution resolve(TomlKey key, boolean create) {
+        if (key == null) throw new NullPointerException("Key may not be null");
+
         Iterator<String> iter = key.iterator();
         if (!iter.hasNext()) throw new IllegalArgumentException("Cannot use empty (zero part) key in TomlTable");
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
@@ -9,215 +9,153 @@ import java.util.*;
 @ApiStatus.Internal
 final class TomlTableImpl implements TomlTable {
 
-    private static @NotNull TomlTableImpl unwrapTable(@NotNull TomlValue value) {
-        return (TomlTableImpl) value.asTable();
+    public static @NotNull TomlTableImpl copyOf(@NotNull TomlTableImpl table) {
+        return new TomlTableImpl(TomlTableBranch.copyOf(table.root));
     }
 
     //
 
-    private final Set<TomlTableImpl> parents = Collections.newSetFromMap(new WeakHashMap<>());
-    private final Map<String, TomlValue> backing = new HashMap<>();
-    private int entryCount = 0;
+    private final TomlTableBranch root;
 
-    TomlTableImpl() { }
+    private TomlTableImpl(@NotNull TomlTableBranch root) {
+        this.root = root;
+    }
+
+    TomlTableImpl() {
+        this(new TomlTableBranch());
+    }
 
     //
 
     @Override
     public int size() {
-        return this.entryCount;
+        return this.root.entryCount();
     }
 
     @Override
     public boolean isEmpty() {
-        return this.entryCount == 0;
+        return this.root.entryCount() == 0;
     }
 
     @Override
     public void clear() {
-        this.backing.clear();
-        this.entryCount = 0;
+        this.root.clear();
     }
 
     @Override
     public @NotNull @Unmodifiable Set<TomlKey> keys(boolean deep) {
-        if (deep) {
-            return new DeepKeySet(this);
-        } else {
-            return new ShallowKeySet(this.backing.keySet());
-        }
+        return deep ?
+                new DeepKeySet(this) :
+                new ShallowKeySet(this.root);
     }
 
     @Override
     public boolean contains(@NotNull TomlKey key) {
-        this.checkValidKey(key);
-        TomlTableImpl head;
-        TomlValue next = this;
-
-        for (String part : key) {
-            if (!next.isTable()) return false;
-            head = unwrapTable(next);
-            next = head.backing.get(part);
-            if (next == null) return false;
-        }
-
-        return true;
+        Resolution r = this.resolve(key, false);
+        if (r == null) return false;
+        return r.branch.get(r.label) != null;
     }
 
     @Override
     public @Nullable TomlValue get(@NotNull TomlKey key) {
-        this.checkValidKey(key);
-        TomlTableImpl head;
-        TomlValue next = this;
-
-        for (String part : key) {
-            if (!next.isTable()) return null;
-            head = unwrapTable(next);
-            next = head.backing.get(part);
-            if (next == null) return null;
-        }
-
-        return next;
+        Resolution r = this.resolve(key, false);
+        if (r == null) return null;
+        TomlTableNode node = r.branch.get(r.label);
+        return this.wrapNode(node);
     }
 
     @Override
     public @Nullable TomlValue put(@NotNull TomlKey key, @NotNull TomlValue value) {
-        this.checkValidKey(key);
-        this.checkValidValue(value);
-        TomlTableImpl head = this;
-
-        Iterator<String> iter = key.iterator();
-        String part;
-        TomlValue v;
-        do {
-            part = iter.next();
-            if (!iter.hasNext()) break;
-            v = head.backing.get(part);
-            if (v == null) {
-                TomlTableImpl n = new TomlTableImpl();
-                n.parents.addAll(this.parents);
-                n.parents.add(head);
-                head.backing.put(part, n);
-                v = n;
-            } else if (!v.isTable()) {
-                throw new IllegalArgumentException("Creating entry at " + key +
-                        " would overwrite an existing non-table entry (" + part + ")");
-            }
-            head = unwrapTable(v);
-        } while (true);
-
-        TomlValue removed = head.backing.put(part, value);
-        int mod = -this.entryCountOf(removed);
+        Resolution r = this.resolve(key, true);
+        TomlTableNode old;
         if (value.isTable()) {
-            TomlTableImpl addedTable = unwrapTable(value);
-            addedTable.parents.addAll(this.parents);
-            addedTable.parents.add(head);
-            mod += addedTable.entryCount;
+            TomlTableImpl tbl = (TomlTableImpl) value.asTable();
+            old = r.branch.put(r.label, tbl.root);
         } else {
-            mod++;
+            TomlTableLeaf leaf = new TomlTableLeaf(value);
+            old = r.branch.put(r.label, leaf);
         }
-        this.modifyEntryCount(mod);
-        return removed;
+        return this.wrapNode(old);
     }
 
     @Override
     public @Nullable TomlValue remove(@NotNull TomlKey key) {
-        this.checkValidKey(key);
-        TomlTableImpl head = this;
+        Resolution r = this.resolve(key, false);
+        if (r == null) return null;
+        TomlTableNode node = r.branch.remove(r.label);
+        return this.wrapNode(node);
+    }
 
+    @Contract("null -> null; !null -> !null")
+    private TomlValue wrapNode(TomlTableNode node) {
+        if (node == null) return null;
+        if (node.isLeaf()) {
+            return node.asLeaf().value();
+        } else {
+            return new TomlTableImpl(node.asBranch());
+        }
+    }
+
+    @Contract("_, true -> !null")
+    private @Nullable Resolution resolve(@NotNull TomlKey key, boolean create) {
         Iterator<String> iter = key.iterator();
-        String part;
-        TomlValue v;
-        do {
-            part = iter.next();
-            if (!iter.hasNext()) break;
-            v = head.backing.get(part);
-            if (v == null || !v.isTable()) return null;
-            head = unwrapTable(v);
-        } while (true);
+        if (!iter.hasNext()) throw new IllegalArgumentException("Cannot use empty (zero part) key in TomlTable");
 
-        TomlValue removed = head.backing.remove(part);
-        if (removed != null){
-            if (removed.isTable()) {
-                TomlTableImpl removedTable = unwrapTable(removed);
-                removedTable.parents.removeAll(this.parents);
-                removedTable.parents.remove(this);
-                this.modifyEntryCount(-removedTable.entryCount);
+        TomlTableBranch head = this.root;
+        String label = iter.next();
+
+        while (iter.hasNext()) {
+            TomlTableNode node = head.get(label);
+            if (node != null && node.isBranch()) {
+                head = node.asBranch();
+            } else if (create) {
+                TomlTableBranch branch = new TomlTableBranch();
+                head.put(label, branch);
+                head = branch;
             } else {
-                this.modifyEntryCount(-1);
+                return null;
             }
+            label = iter.next();
         }
-        return removed;
-    }
 
-    public void putAll(@NotNull TomlTableImpl other) {
-        this.putAll0(TomlKey.literal(), other.backing);
-    }
-
-    private void putAll0(@NotNull TomlKey prefix, @NotNull Map<String, TomlValue> map) {
-        TomlKey key;
-        TomlValue value;
-        for (Map.Entry<String, TomlValue> entry : map.entrySet()) {
-            key = TomlKey.join(prefix, TomlKey.literal(entry.getKey()));
-            value = entry.getValue();
-            if (value.isTable()) {
-                this.putAll0(key, unwrapTable(value).backing);
-            } else {
-                this.put(key, value);
-            }
-        }
-    }
-
-    @Contract("null -> fail")
-    private void checkValidKey(TomlKey key) {
-        if (key == null) throw new NullPointerException("Key may not be null");
-        if (key.isEmpty()) throw new IllegalArgumentException("Key is empty (0 parts)");
-    }
-
-    private int entryCountOf(@Nullable TomlValue value) {
-        if (value == null) return 0;
-        if (value.isTable()) return unwrapTable(value).entryCount;
-        return 1;
-    }
-
-    private void modifyEntryCount(int mod) {
-        this.entryCount += mod;
-        for (TomlTableImpl parent : this.parents) parent.entryCount += mod;
-    }
-
-    @Contract("null -> fail")
-    private void checkValidValue(TomlValue value) {
-        if (value == null) throw new NullPointerException("Value may not be null");
-        if (value.isTable()) {
-            if (this.equals(value)) {
-                throw new IllegalArgumentException("Cannot add table to itself");
-            }
-            TomlTableImpl table = unwrapTable(value);
-            if (this.isInAncestry(table) || table.isInAncestry(this)) {
-                throw new IllegalArgumentException("Cannot create cyclic table relationship");
-            }
-        }
-    }
-
-    private boolean isInAncestry(@NotNull TomlTableImpl value) {
-        return this.parents.contains(value);
+        return new Resolution(head, label);
     }
 
     //
 
+    private static final class Resolution {
+
+        final TomlTableBranch branch;
+        final String label;
+
+        Resolution(
+                @NotNull TomlTableBranch branch,
+                @NotNull String label
+        ) {
+            this.branch = branch;
+            this.label = label;
+        }
+
+    }
+
     private static final class ShallowKeySet extends AbstractSet<TomlKey> {
 
-        private final Set<String> backing;
+        private final TomlTableBranch parent;
 
-        ShallowKeySet(@NotNull Set<String> backing) {
-            this.backing = backing;
+        ShallowKeySet(@NotNull TomlTableBranch parent) {
+            this.parent = parent;
         }
 
         //
 
         @Override
         public int size() {
-            return this.backing.size();
+            return this.parent.keyCount();
+        }
+
+        @Override
+        public @NotNull Iter iterator() {
+            return new Iter(this.parent.keys().iterator());
         }
 
         @Override
@@ -225,12 +163,7 @@ final class TomlTableImpl implements TomlTable {
             if (!(o instanceof TomlKey)) return false;
             TomlKey key = (TomlKey) o;
             if (key.size() != 1) return false;
-            return this.backing.contains(key.get(0));
-        }
-
-        @Override
-        public @NotNull Iterator<TomlKey> iterator() {
-            return new Iter(this.backing.iterator());
+            return this.parent.get(key.get(0)) != null;
         }
 
         //
@@ -271,7 +204,7 @@ final class TomlTableImpl implements TomlTable {
 
         @Override
         public int size() {
-            return this.parent.entryCount;
+            return this.parent.size();
         }
 
         @Override
@@ -282,66 +215,102 @@ final class TomlTableImpl implements TomlTable {
 
         @Override
         public @NotNull Iterator<TomlKey> iterator() {
-            return new Iter(this.parent);
+            return new Iter(this.parent.root);
         }
 
         //
 
         private static final class Iter implements Iterator<TomlKey> {
 
-            private final Queue<QueuedTable> queue;
-            private TomlKey prefix;
-            private Iterator<Map.Entry<String, TomlValue>> backing;
-            private int remaining;
+            private final Queue<SubIter> queue;
 
-            Iter(@NotNull TomlTableImpl start) {
+            Iter(@NotNull TomlTableBranch branch) {
                 this.queue = new LinkedList<>();
-                this.prefix = TomlKey.literal();
-                this.backing = start.backing.entrySet().iterator();
-                this.remaining = start.entryCount;
+                this.queue.add(new SubIter(TomlKey.literal(), branch, this.queue));
             }
 
             //
 
+            private @Nullable SubIter acquire() {
+                SubIter ret = this.queue.peek();
+                while (ret != null) {
+                    if (ret.hasNext()) return ret;
+                    this.queue.poll();
+                    ret = this.queue.peek();
+                }
+                return null;
+            }
+
             @Override
             public boolean hasNext() {
-                return this.remaining > 0;
+                return this.acquire() != null;
             }
 
             @Override
             public @NotNull TomlKey next() {
-                if (this.remaining <= 0) throw new NoSuchElementException();
-
-                while (true) {
-                    while (this.backing.hasNext()) {
-                        Map.Entry<String, TomlValue> entry = this.backing.next();
-                        TomlKey key = TomlKey.join(this.prefix, TomlKey.literal(entry.getKey()));
-                        TomlValue value = entry.getValue();
-                        if (value.isTable()) {
-                            this.queue.add(new QueuedTable(key, unwrapTable(value)));
-                        } else {
-                            this.remaining--;
-                            return key;
-                        }
-                    }
-
-                    QueuedTable queued = this.queue.poll();
-                    if (queued == null) throw new ConcurrentModificationException();
-                    this.prefix = queued.prefix;
-                    this.backing = queued.table.backing.entrySet().iterator();
-                }
+                SubIter sub = this.acquire();
+                if (sub == null) throw new NoSuchElementException();
+                return sub.next();
             }
 
             //
 
-            private static final class QueuedTable {
+            private static final class SubIter implements Iterator<TomlKey> {
 
                 private final TomlKey prefix;
-                private final TomlTableImpl table;
+                private final TomlTableBranch branch;
+                private final Iterator<String> backing;
+                private final Queue<SubIter> queue;
+                private TomlKey head;
 
-                QueuedTable(@NotNull TomlKey prefix, @NotNull TomlTableImpl table) {
+                SubIter(
+                        @NotNull TomlKey prefix,
+                        @NotNull TomlTableBranch branch,
+                        @NotNull Queue<SubIter> queue
+                ) {
                     this.prefix = prefix;
-                    this.table = table;
+                    this.branch = branch;
+                    this.backing = branch.keys().iterator();
+                    this.queue = queue;
+                }
+
+                //
+
+                private void compute() {
+                    if (this.head != null) return;
+
+                    String label;
+                    TomlKey key;
+                    TomlTableNode node;
+
+                    while (this.backing.hasNext()) {
+                        label = this.backing.next();
+                        key = TomlKey.join(this.prefix, TomlKey.literal(label));
+                        node = this.branch.get(label);
+                        if (node == null) throw new ConcurrentModificationException();
+                        if (node.isBranch()) {
+                            this.queue.add(new SubIter(key, node.asBranch(), this.queue));
+                        } else if (node.isLeaf()) {
+                            this.head = key;
+                            break;
+                        }
+                    }
+                }
+
+                @Override
+                public boolean hasNext() {
+                    this.compute();
+                    return this.head != null;
+                }
+
+                @Override
+                public @NotNull TomlKey next() {
+                    this.compute();
+                    TomlKey ret = this.head;
+                    this.head = null;
+                    if (ret == null)
+                        throw new NoSuchElementException();
+                    return ret;
                 }
 
             }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableLeaf.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableLeaf.java
@@ -1,0 +1,55 @@
+package io.github.wasabithumb.jtoml.value.table;
+
+import io.github.wasabithumb.jtoml.value.TomlValue;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+final class TomlTableLeaf implements TomlTableNode {
+
+    private final TomlValue value;
+
+    TomlTableLeaf(@NotNull TomlValue value) {
+        this.value = value;
+    }
+
+    //
+
+    public @NotNull TomlValue value() {
+        return this.value;
+    }
+
+    // START Node Super
+
+
+    @Override
+    public int entryCount() {
+        return 1;
+    }
+
+    @Override
+    public boolean isBranch() {
+        return false;
+    }
+
+    @Override
+    @Contract("-> fail")
+    public @NotNull TomlTableBranch asBranch() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return true;
+    }
+
+    @Override
+    @Contract("-> this")
+    public @NotNull TomlTableLeaf asLeaf() {
+        return this;
+    }
+
+    // END Node Super
+
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableNode.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableNode.java
@@ -1,0 +1,19 @@
+package io.github.wasabithumb.jtoml.value.table;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+@ApiStatus.Internal
+interface TomlTableNode {
+
+    int entryCount();
+
+    boolean isBranch();
+
+    @NotNull TomlTableBranch asBranch() throws UnsupportedOperationException;
+
+    boolean isLeaf();
+
+    @NotNull TomlTableLeaf asLeaf() throws UnsupportedOperationException;
+
+}

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/io/TableWriter.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/io/TableWriter.java
@@ -16,6 +16,8 @@ import io.github.wasabithumb.jtoml.value.table.TomlTable;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public final class TableWriter implements Closeable {
@@ -83,10 +85,10 @@ public final class TableWriter implements Closeable {
         // Bin 1: Arrays
         // Bin 2: Arrays of Tables
         // Bin 3: Tables
-        KeyBin b0 = new KeyBin(count);
-        KeyBin b1 = new KeyBin(count);
-        KeyBin b2 = new KeyBin(count);
-        KeyBin b3 = new KeyBin(count);
+        List<TomlKey> b0 = new ArrayList<>(count);
+        List<TomlKey> b1 = new ArrayList<>(count);
+        List<TomlKey> b2 = new ArrayList<>(count);
+        List<TomlKey> b3 = new ArrayList<>(count);
         for (TomlKey tk : set) {
             TomlValue tv = table.get(tk);
             assert tv != null;
@@ -103,29 +105,25 @@ public final class TableWriter implements Closeable {
             }
         }
 
-        if (andHeader && (this.options.get(JTomlOption.WRITE_EMPTY_TABLES) || b0.size() != 0 || b1.size() != 0)) {
+        if (andHeader && (this.options.get(JTomlOption.WRITE_EMPTY_TABLES) || !b0.isEmpty() || !b1.isEmpty())) {
             this.writeTableHeader(prefix, false);
         }
 
-        TomlKey nextKey;
         TomlValue nextValue;
 
-        for (int i=0; i < b0.size(); i++) {
-            nextKey = b0.get(i);
+        for (TomlKey nextKey : b0) {
             nextValue = table.get(nextKey);
             assert nextValue != null;
             this.writePrimitive(nextKey, nextValue.asPrimitive());
         }
 
-        for (int i=0; i < b1.size(); i++) {
-            nextKey = b1.get(i);
+        for (TomlKey nextKey : b1) {
             nextValue = table.get(nextKey);
             assert nextValue != null;
             this.writeArray(nextKey, nextValue.asArray());
         }
 
-        for (int i=0; i < b2.size(); i++) {
-            nextKey = b2.get(i);
+        for (TomlKey nextKey : b2) {
             nextValue = table.get(nextKey);
             assert nextValue != null;
             nextKey = TomlKey.join(prefix, nextKey);
@@ -138,8 +136,7 @@ public final class TableWriter implements Closeable {
             }
         }
 
-        for (int i=0; i < b3.size(); i++) {
-            nextKey = b3.get(i);
+        for (TomlKey nextKey : b3) {
             nextValue = table.get(nextKey);
             assert nextValue != null;
             nextKey = TomlKey.join(prefix, nextKey);
@@ -314,48 +311,6 @@ public final class TableWriter implements Closeable {
     @Override
     public void close() throws TomlException {
         this.out.close();
-    }
-
-    //
-
-    private static final class KeyBin {
-
-        private final TomlKey[] arr;
-        private int head;
-
-        KeyBin(int capacity) {
-            this.arr = new TomlKey[capacity];
-            this.head = 0;
-        }
-
-        //
-
-        public int size() {
-            return this.head;
-        }
-
-        public void add(@NotNull TomlKey key) {
-            int idx = 0;
-            int cmp;
-            while (idx < this.head) {
-                cmp = key.compareTo(this.arr[idx]);
-                if (cmp < 0) {
-                    break;
-                } else if (cmp == 0) {
-                    return;
-                } else {
-                    idx++;
-                }
-            }
-            System.arraycopy(this.arr, idx, this.arr, idx + 1, this.head - idx);
-            this.arr[idx] = key;
-            this.head++;
-        }
-
-        public @NotNull TomlKey get(int index) {
-            return this.arr[index];
-        }
-
     }
 
 }


### PR DESCRIPTION
- Improve TomlTable javadocs
- Improve code quality & maintainability of TomlTable related classes
- Add ``#contains(CharSequence)`` which aliases ``#contains(TomlKey)`` in a similar way to other existing methods
- TomlTable key sets are now inherently ordered (depth-first lexicographically). The internal structure of a TomlTable now resembles a TreeMap
- TomlTable objects now permit clobbering; API users may overwrite and extend values with impunity. Only the parser is subject to clobbering/extension rules
- Less overhead; good time complexity for typical TOML structures
- ``TomlTable#copyOf`` now works as intended
- Removed ``TableWriter$KeyBin``; no longer necessary due to aforementioned changes
