### PR TITLE
Fully document API classes

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializable.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializable.java
@@ -1,8 +1,22 @@
 package io.github.wasabithumb.jtoml.serial;
 
 /**
- * Marker class for classes which may be serialized
- * with the reflection serializer.
- * Requires {@code jtoml-serializer-reflect} to work as intended.
+ * <p>
+ *     Marker interface for classes which may be serialized
+ *     with the reflection serializer.
+ *     Requires {@code jtoml-serializer-reflect} to work as intended.
+ * </p>
+ * <p>
+ *     When de/serializing a {@link TomlSerializable} type, all
+ *     declared non-transient fields are considered. Such fields
+ *     declared in superclasses are also considered, as long as each
+ *     superclass is itself marked as {@link TomlSerializable}
+ *     either directly or by inheritance.
+ * </p>
+ * <p>
+ *     A {@link TomlSerializable} type that is not a <a href="https://openjdk.org/jeps/395">record</a>
+ *     must have a no-args constructor. If the type is a record, it should not implement the
+ *     {@link TomlSerializable} marker interface. This marker is always ignored for records.
+ * </p>
  */
 public interface TomlSerializable { }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializer.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializer.java
@@ -5,16 +5,39 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * <p>
- *     An abstraction for facets which can transform
- *     TOML tables to/from some other type in-memory.
- *     Useful for digesting and converting configuration
- *     files.
- * </p>
- * <p>
- *     No serializers are present in the base JToml artifact,
- *     they are separate dependencies.
- * </p>
+ * An abstraction for facets which can transform
+ * TOML tables to/from some other type in-memory.
+ *
+ * <h2>Available Serializers</h2>
+ * <table border="1">
+ *     <tr>
+ *         <th>Name</th>
+ *         <th>Artifact</th>
+ *         <th>Supported Type(s)</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code PlainTextTomlSerializer}</td>
+ *         <td>N/A</td>
+ *         <td>{@link String}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code GsonTomlSerializer}</td>
+ *         <td>{@code jtoml-serializer-gson}</td>
+ *         <td><a href="https://javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/JsonObject.html">{@code JsonObject}</a></td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code ReflectTomlSerializer}</td>
+ *         <td>{@code jtoml-serializer-reflect}</td>
+ *         <td>
+ *             {@link TomlSerializable},
+ *             {@link java.util.Map Map&lt;String, ?&gt;},
+ *             {@link java.util.List List&lt;?&gt;},
+ *             <a href="https://openjdk.org/jeps/395">records</a>,
+ *             primitives (boxed and unboxed) and
+ *             arrays
+ *         </td>
+ *     </tr>
+ * </table>
  */
 public interface TomlSerializer<I, O> {
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
@@ -3,8 +3,10 @@ package io.github.wasabithumb.jtoml.serial.plain;
 import io.github.wasabithumb.jtoml.JToml;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+@ApiStatus.Internal
 public final class PlainTextTomlSerializer implements TomlSerializer.Symmetric<String> {
 
     private final JToml instance;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/TomlValue.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/TomlValue.java
@@ -16,28 +16,73 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.NonExtendable
 public interface TomlValue {
 
+    /**
+     * <p>
+     *     Returns true if the value represents a {@link TomlPrimitive primitive}
+     *     and {@link #asPrimitive()} may be called.
+     * </p>
+     * <p>
+     *     The return value of this method may or may not be identical to
+     *     {@code this instanceof TomlPrimitive}.
+     * </p>
+     */
     default boolean isPrimitive() {
         return this instanceof TomlPrimitive;
     }
 
+    /**
+     * Converts this value to a {@link TomlPrimitive primitive}.
+     * Whether the method returns {@code this} or not is an implementation detail.
+     * @throws UnsupportedOperationException Value does not represent a primitive (see {@link #isPrimitive()})
+     */
     default @NotNull TomlPrimitive asPrimitive() throws UnsupportedOperationException {
         if (this instanceof TomlPrimitive) return (TomlPrimitive) this;
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * <p>
+     *     Returns true if the value represents a {@link TomlArray array}
+     *     and {@link #asArray()} may be called.
+     * </p>
+     * <p>
+     *     The return value of this method may or may not be identical to
+     *     {@code this instanceof TomlArray}.
+     * </p>
+     */
     default boolean isArray() {
         return this instanceof TomlArray;
     }
 
+    /**
+     * Converts this value to a {@link TomlArray array}.
+     * Whether the method returns {@code this} or not is an implementation detail.
+     * @throws UnsupportedOperationException Value does not represent an array (see {@link #isArray()})
+     */
     default @NotNull TomlArray asArray() throws UnsupportedOperationException {
         if (this instanceof TomlArray) return (TomlArray) this;
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * <p>
+     *     Returns true if the value represents a {@link TomlTable table}
+     *     and {@link #asTable()} may be called.
+     * </p>
+     * <p>
+     *     The return value of this method may or may not be identical to
+     *     {@code this instanceof TomlTable}.
+     * </p>
+     */
     default boolean isTable() {
         return this instanceof TomlTable;
     }
 
+    /**
+     * Converts this value to a {@link TomlTable table}.
+     * Whether the method returns {@code this} or not is an implementation detail.
+     * @throws UnsupportedOperationException Value does not represent a table (see {@link #isTable()})
+     */
     default @NotNull TomlTable asTable() throws UnsupportedOperationException {
         if (this instanceof TomlTable) return (TomlTable) this;
         throw new UnsupportedOperationException();

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArray.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArray.java
@@ -5,19 +5,25 @@ import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Array;
 import java.util.RandomAccess;
 
+/**
+ * A list of {@link TomlValue TOML values}
+ * @see #create(int)
+ * @see #create()
+ */
 @ApiStatus.NonExtendable
 public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue {
 
+    /** Creates a new TomlArray with the specified initial capacity */
     @Contract("_ -> new")
     static @NotNull TomlArray create(int initialCapacity) {
         return new TomlArrayImpl(initialCapacity);
     }
 
+    /** Creates a new empty TomlArray */
     @Contract("-> new")
     static @NotNull TomlArray create() {
         return new TomlArrayImpl();
@@ -25,48 +31,91 @@ public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue 
 
     //
 
+    /**
+     * Reports the number of elements in this array
+     */
     @Contract(pure = true)
     int size();
 
+    /**
+     * Returns the Nth element in this array
+     * @throws IndexOutOfBoundsException Index is less than 0 or not less than {@link #size()}
+     */
     @NotNull TomlValue get(int index) throws IndexOutOfBoundsException;
 
+    /**
+     * Adds a new element to this array
+     * @throws NullPointerException Value is null
+     */
     @Contract(value = "null -> fail", mutates = "this")
     void add(TomlValue value);
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @throws NullPointerException Value is null
+     * @see TomlPrimitive#of(String)
+     */
     @Contract(mutates = "this")
     default void add(@NotNull String value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @see TomlPrimitive#of(boolean)
+     */
     @Contract(mutates = "this")
     default void add(boolean value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @see TomlPrimitive#of(long)
+     */
     @Contract(mutates = "this")
     default void add(long value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @see TomlPrimitive#of(int)
+     */
     @Contract(mutates = "this")
     default void add(int value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @see TomlPrimitive#of(double)
+     */
     @Contract(mutates = "this")
     default void add(double value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds a new element to this array after wrapping it into a {@link TomlPrimitive}
+     * @see TomlPrimitive#of(float)
+     */
     @Contract(mutates = "this")
     default void add(float value) {
         this.add(TomlPrimitive.of(value));
     }
 
+    /**
+     * Adds to this array all the values
+     * contained within {@code source}
+     */
     default void addAll(@NotNull Iterable<? extends TomlValue> source) {
         for (TomlValue tv : source) this.add(tv);
     }
 
+    /**
+     * Returns true if the given value is present within the array
+     */
     @Contract("null -> false")
     default boolean contains(TomlValue value) {
         if (value == null) return false;
@@ -76,9 +125,18 @@ public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue 
         return false;
     }
 
+    /**
+     * Removes the Nth element from this array
+     * @return The element that was removed
+     * @throws IndexOutOfBoundsException Index is less than 0 or not less than {@link #size()}
+     */
     @Contract(value = "_ -> !null", mutates = "this")
     TomlValue remove(int index) throws IndexOutOfBoundsException;
 
+    /**
+     * Removes the first occurrence of the specified value from this array
+     * @return True if any element was removed
+     */
     @Contract(value = "null -> false", mutates = "this")
     default boolean remove(TomlValue value) {
         if (value == null) return false;
@@ -91,9 +149,17 @@ public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue 
         return false;
     }
 
+    /**
+     * Sets the Nth element of this array to the given value
+     * @return The value previously set at this index
+     * @throws IndexOutOfBoundsException Index is less than 0 or not less than {@link #size()}
+     */
     @Contract(value = "_, null -> fail", mutates = "this")
-    @Nullable TomlValue set(int index, TomlValue value) throws IndexOutOfBoundsException;
+    @NotNull TomlValue set(int index, TomlValue value) throws IndexOutOfBoundsException;
 
+    /**
+     * Returns a new array with the same length and values as this object
+     */
     @Contract("-> new")
     default @NotNull TomlValue @NotNull [] toArray() {
         final int len = this.size();
@@ -102,6 +168,11 @@ public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue 
         return vs;
     }
 
+    /**
+     * Returns a new array with the same length and values as this object,
+     * asserting that each element is an instance of the given class
+     * @throws ClassCastException One or more elements could not be cast to the given type
+     */
     @SuppressWarnings("unchecked")
     @Contract("_ -> new")
     default <T extends TomlValue> @NotNull T @NotNull [] toArray(@NotNull Class<T> valueType) throws ClassCastException {

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
@@ -36,7 +36,7 @@ final class TomlArrayImpl implements TomlArray {
 
     @Override
     public void add(TomlValue value) {
-        if (value == null) throw new IllegalArgumentException("Cannot add null to TomlArray");
+        if (value == null) throw new NullPointerException("Cannot add null to TomlArray");
         this.backing.add(value);
     }
 
@@ -46,8 +46,8 @@ final class TomlArrayImpl implements TomlArray {
     }
 
     @Override
-    public @Nullable TomlValue set(int index, TomlValue value) throws IndexOutOfBoundsException {
-        if (value == null) throw new IllegalArgumentException("Cannot insert null into TomlArray");
+    public @NotNull TomlValue set(int index, TomlValue value) throws IndexOutOfBoundsException {
+        if (value == null) throw new NullPointerException("Cannot insert null into TomlArray");
         return this.backing.set(index, value);
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
@@ -19,36 +19,78 @@ import java.util.Objects;
 @ApiStatus.NonExtendable
 public interface TomlPrimitive extends TomlValue {
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#STRING STRING}
+     * wrapping the given string value
+     * @throws NullPointerException Value is null
+     */
     @Contract("null -> fail; !null -> new")
     static @NotNull TomlPrimitive of(String value) {
         return new StringTomlPrimitive(Objects.requireNonNull(value));
     }
 
+    /**
+     * Provides a primitive of type {@link TomlPrimitiveType#BOOLEAN BOOLEAN}
+     * wrapping the given boolean value
+     */
     static @NotNull TomlPrimitive of(boolean value) {
         return value ? BooleanTomlPrimitive.TRUE : BooleanTomlPrimitive.FALSE;
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#INTEGER INTEGER}
+     * wrapping the given long value
+     */
+    @Contract("_ -> new")
     static @NotNull TomlPrimitive of(long value) {
         return new IntegerTomlPrimitive(value);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#INTEGER INTEGER}
+     * wrapping the given integer value after a widening conversion to {@link Long}
+     */
+    @Contract("_ -> new")
     static @NotNull TomlPrimitive of(int value) {
         return of((long) value);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#FLOAT FLOAT}
+     * wrapping the given double value
+     */
     static @NotNull TomlPrimitive of(double value) {
         return new FloatTomlPrimitive(value);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#FLOAT FLOAT}
+     * wrapping the given float value after a widening conversion to {@link Double}
+     */
     static @NotNull TomlPrimitive of(float value) {
         return of((double) value);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#OFFSET_DATE_TIME OFFSET_DATE_TIME}
+     * wrapping the given {@link OffsetDateTime}
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     */
     @Contract("null -> fail; !null -> new")
     static @NotNull TomlPrimitive of(OffsetDateTime value) throws TomlValueException {
         return new OffsetDateTimeTomlPrimitive(Objects.requireNonNull(value));
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_DATE_TIME LOCAL_DATE_TIME}
+     * wrapping the given {@link LocalDateTime}
+     * @param offset Offset to use when coercing this value to an {@link OffsetDateTime}.
+     *               If null, {@link ZoneOffset#UTC} is used. This does not change the value
+     *               of the resulting primitive.
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     */
     @Contract("null, _ -> fail; !null, _ -> new")
     static @NotNull TomlPrimitive of(LocalDateTime value, @Nullable ZoneOffset offset) throws TomlValueException {
         return new LocalDateTimeTomlPrimitive(
@@ -57,11 +99,27 @@ public interface TomlPrimitive extends TomlValue {
         );
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_DATE_TIME LOCAL_DATE_TIME}
+     * wrapping the given {@link LocalDateTime}
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     * @see #of(LocalDateTime, ZoneOffset)
+     */
     @Contract("null -> fail; !null -> new")
     static @NotNull TomlPrimitive of(LocalDateTime value) throws TomlValueException {
         return of(value, null);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_DATE LOCAL_DATE}
+     * wrapping the given {@link LocalDate}
+     * @param offset Offset to use when coercing this value to an {@link OffsetDateTime}.
+     *               If null, {@link ZoneOffset#UTC} is used. This does not change the value
+     *               of the resulting primitive.
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     */
     @Contract("null, _ -> fail; !null, _ -> new")
     static @NotNull TomlPrimitive of(LocalDate value, @Nullable ZoneOffset offset) throws TomlValueException {
         return new LocalDateTomlPrimitive(
@@ -70,11 +128,27 @@ public interface TomlPrimitive extends TomlValue {
         );
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_DATE LOCAL_DATE}
+     * wrapping the given {@link LocalDate}
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     * @see #of(LocalDate, ZoneOffset)
+     */
     @Contract("null -> fail; !null -> new")
     static @NotNull TomlPrimitive of(LocalDate value) throws TomlValueException {
         return of(value, null);
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_TIME LOCAL_TIME}
+     * wrapping the given {@link LocalTime}
+     * @param offset Offset to use when coercing this value to an {@link OffsetDateTime}.
+     *               If null, {@link ZoneOffset#UTC} is used. This does not change the value
+     *               of the resulting primitive.
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     */
     @Contract("null, _ -> fail; !null, _ -> new")
     static @NotNull TomlPrimitive of(LocalTime value, @Nullable ZoneOffset offset) {
         return new LocalTimeTomlPrimitive(
@@ -83,6 +157,13 @@ public interface TomlPrimitive extends TomlValue {
         );
     }
 
+    /**
+     * Creates a primitive of type {@link TomlPrimitiveType#LOCAL_TIME LOCAL_TIME}
+     * wrapping the given {@link LocalTime}
+     * @throws NullPointerException Value is null
+     * @throws TomlValueException Provided date has a year outside the range 0 to 9999
+     * @see #of(LocalTime, ZoneOffset)
+     */
     @Contract("null -> fail; !null -> new")
     static @NotNull TomlPrimitive of(LocalTime value) {
         return of(value, null);
@@ -107,88 +188,267 @@ public interface TomlPrimitive extends TomlValue {
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#STRING}, meaning that
+     * the output of {@link #asString()} is identical to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isString() {
         return this.type() == TomlPrimitiveType.STRING;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this
+     * primitive to a string.
+     */
     @NotNull String asString();
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#BOOLEAN}, meaning that
+     * the output of {@link #asBoolean()} is equal to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isBoolean() {
         return this.type() == TomlPrimitiveType.BOOLEAN;
     }
 
+    /**
+     * <p>
+     *     Coerces the {@link #value() value} of this
+     *     primitive to a boolean.
+     * </p>
+     * <ul>
+     *     <li>
+     *         Boolean primitives will return their
+     *         stored value
+     *     </li>
+     *     <li>
+     *         String primitives equal to {@code "false"} will
+     *         return false, otherwise true
+     *     </li>
+     *     <li>
+     *         Date-Time primitives will return true
+     *     </li>
+     *     <li>
+     *         Integer and Float primitives that are arithmetically
+     *         equal to 0 will return false, otherwise true
+     *     </li>
+     * </ul>
+     */
     boolean asBoolean();
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#INTEGER}, meaning that
+     * the output of {@link #asLong()} is equal to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isInteger() {
         return this.type() == TomlPrimitiveType.INTEGER;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to an integer.
+     * <ul>
+     *     <li>
+     *         Integer primitives will return their stored value
+     *     </li>
+     *     <li>
+     *         String primitives will attempt to parse their value as a
+     *         long, throwing {@link NumberFormatException} if not possible
+     *     </li>
+     *     <li>
+     *         Date-Time primitives will return their value after coercion to
+     *         {@link OffsetDateTime} as epoch millis
+     *     </li>
+     *     <li>
+     *         Boolean primitives will return 1 if true and 0 if false
+     *     </li>
+     * </ul>
+     * @throws ArithmeticException The intrinsic or coerced value of this primitive
+     *                             (as a long) cannot be losslessly converted to an integer
+     * @see #asLong()
+     */
     default int asInteger() throws ArithmeticException {
         return Math.toIntExact(this.asLong());
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a long.
+     * <ul>
+     *     <li>
+     *         Integer primitives will return their stored value
+     *     </li>
+     *     <li>
+     *         String primitives will attempt to parse their value as a
+     *         long, throwing {@link NumberFormatException} if not possible
+     *     </li>
+     *     <li>
+     *         Date-Time primitives will return their value after coercion to
+     *         {@link OffsetDateTime} as epoch millis
+     *     </li>
+     *     <li>
+     *         Boolean primitives will return 1 if true and 0 if false
+     *     </li>
+     * </ul>
+     * @see #asInteger()
+     */
     long asLong();
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#FLOAT}, meaning that
+     * the output of {@link #asDouble()} is equal to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isFloat() {
         return this.type() == TomlPrimitiveType.FLOAT;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a float.
+     * Output is identical to that of {@link #asDouble()} after narrowing conversion
+     * to {@code float}.
+     * @see #asDouble()
+     */
     default float asFloat() {
         return (float) this.asDouble();
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a double.
+     * If this is a float primitive, returns the stored value. Otherwise, returns
+     * the closest double value to that of {@link #asLong()}.
+     * @see #asFloat()
+     */
     double asDouble();
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#OFFSET_DATE_TIME}, meaning that
+     * the output of {@link #asOffsetDateTime()} is identical to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isOffsetDateTime() {
         return this.type() == TomlPrimitiveType.OFFSET_DATE_TIME;
     }
 
+    /**
+     * Returns a {@link Instant} that represents the same moment in time
+     * as the output of {@link #asOffsetDateTime()}.
+     */
     default @NotNull Instant asInstant() {
         return this.asOffsetDateTime().toInstant();
     }
 
+    /**
+     * Returns a {@link Date} that represents the same moment in time
+     * as the output of {@link #asOffsetDateTime()}.
+     */
     default @NotNull Date asDate() {
         return Date.from(this.asInstant());
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to an {@link OffsetDateTime}.
+     * <ul>
+     *     <li>For Offset Date-Time primitives, returns the stored value</li>
+     *     <li>For Local Date-Time primitives, pairs the stored value with the configured offset</li>
+     *     <li>For Local Date primitives, evaluates the stored date at the 0th hour and configured offset</li>
+     *     <li>For Local Time primitives, evaluates the stored time at the 0th date and configured offset</li>
+     *     <li>For Integer primitives, interprets the stored value as epoch millis</li>
+     *     <li>For all other values, throws {@link UnsupportedOperationException}</li>
+     * </ul>
+     */
     default @NotNull OffsetDateTime asOffsetDateTime() {
         throw new UnsupportedOperationException();
     }
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#LOCAL_DATE_TIME}, meaning that
+     * the output of {@link #asLocalDateTime()} is identical to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isLocalDateTime() {
         return this.type() == TomlPrimitiveType.LOCAL_DATE_TIME;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a {@link LocalDateTime}.
+     * <ul>
+     *     <li>For Offset Date-Time primitives, returns the stored value after discarding the offset</li>
+     *     <li>For Local Date-Time primitives, returns the stored value</li>
+     *     <li>For Local Date primitives, evaluates the stored date at the 0th hour</li>
+     *     <li>For Local Time primitives, evaluates the stored time at the 0th date</li>
+     *     <li>For Integer primitives, interprets the stored value as epoch millis</li>
+     *     <li>For all other values, throws {@link UnsupportedOperationException}</li>
+     * </ul>
+     */
     default @NotNull LocalDateTime asLocalDateTime() {
         throw new UnsupportedOperationException();
     }
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#LOCAL_DATE}, meaning that
+     * the output of {@link #asLocalDate()} is identical to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isLocalDate() {
         return this.type() == TomlPrimitiveType.LOCAL_DATE;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a {@link LocalDate}.
+     * <ul>
+     *     <li>For Offset Date-Time primitives, returns the stored value after discarding the time and offset</li>
+     *     <li>For Local Date-Time primitives, returns the stored value after discarding the time</li>
+     *     <li>For Local Date primitives, returns the stored date</li>
+     *     <li>For Local Time primitives, returns the 0th date</li>
+     *     <li>For all other values, throws {@link UnsupportedOperationException}</li>
+     * </ul>
+     */
     default @NotNull LocalDate asLocalDate() {
         throw new UnsupportedOperationException();
     }
 
     //
 
+    /**
+     * Checks if the {@link #type() type} of this primitive is
+     * equal to {@link TomlPrimitiveType#LOCAL_TIME}, meaning that
+     * the output of {@link #asLocalTime()} is identical to the
+     * {@link #value() value} of this primitive.
+     */
     default boolean isLocalTime() {
         return this.type() == TomlPrimitiveType.LOCAL_TIME;
     }
 
+    /**
+     * Coerces the {@link #value() value} of this primitive to a {@link LocalTime}.
+     * <ul>
+     *     <li>For Offset Date-Time primitives, returns the stored value after discarding the date and offset</li>
+     *     <li>For Local Date-Time primitives, returns the stored value after discarding the date</li>
+     *     <li>For Local Date primitives, returns the 0th hour</li>
+     *     <li>For Local Time primitives, returns the stored value</li>
+     *     <li>For all other values, throws {@link UnsupportedOperationException}</li>
+     * </ul>
+     */
     default @NotNull LocalTime asLocalTime() {
         throw new UnsupportedOperationException();
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/TableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/TableTypeModel.java
@@ -20,13 +20,13 @@ public interface TableTypeModel<T> extends TypeModel<T> {
     static <O> @Nullable TableTypeModel<O> match(@NotNull ParameterizedClass<O> pc) {
         Class<O> raw = pc.raw();
 
-        // TomlSerializable
-        if (TomlSerializable.class.isAssignableFrom(raw))
-            return (TableTypeModel<O>) Serializable.create(raw);
-
         // Record
         if (RecordSupport.isRecord(raw))
             return new Record<>(raw);
+
+        // TomlSerializable
+        if (TomlSerializable.class.isAssignableFrom(raw))
+            return (TableTypeModel<O>) Serializable.create(raw);
 
         // TomlTable
         if (TomlTable.class.equals(raw))


### PR DESCRIPTION
Some minor changes also made to code to fulfill documented contracts, for instance record serialization always takes priority over ``TomlSerializable`` serialization