### PR TITLE
Fix regression in float serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ methods for parsing, slicing and joining.
 #### Gradle (Kotlin)
 ```kotlin
 dependencies {
-    implementation("io.github.wasabithumb:jtoml:0.6.0")
+    implementation("io.github.wasabithumb:jtoml:0.6.1")
 }
 ```
 
 #### Gradle (Groovy)
 ```groovy
 dependencies {
-    implementation 'io.github.wasabithumb:jtoml:0.6.0'
+    implementation 'io.github.wasabithumb:jtoml:0.6.1'
 }
 ```
 
@@ -37,7 +37,7 @@ dependencies {
     <dependency>
         <groupId>io.github.wasabithumb</groupId>
         <artifactId>jtoml</artifactId>
-        <version>0.6.0</version>
+        <version>0.6.1</version>
         <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
@@ -20,10 +20,7 @@ final class FloatTomlPrimitive extends AbstractTomlPrimitive<Double> {
         if (value == Double.POSITIVE_INFINITY) return "inf";
         if (value == Double.NEGATIVE_INFINITY) return "-inf";
         if (Double.isNaN(value)) return "nan";
-        if ((value % 1) == 0) {
-            if (Double.doubleToLongBits(value) == -9223372036854775808L) return "-0";
-            return Long.toString((long) value);
-        }
+        if (Double.doubleToLongBits(value) == -9223372036854775808L) return "-0.0";
         return NUMBER_FORMAT.get().format(value);
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ allprojects {
     apply(plugin = "net.thebugmc.gradle.sonatype-central-portal-publisher")
 
     group = "io.github.wasabithumb"
-    version = "0.6.0"
+    version = "0.6.1"
 
     dependencies {
         compileOnly("org.jetbrains:annotations:26.0.1")


### PR DESCRIPTION
#13 removed [some code](https://github.com/WasabiThumb/jtoml/pull/13/files#diff-604eec78de464cbe966884eff165ba2f45db131f100bffaa4458bc344e5dd7bbL174) that forced float primitives to serialize with at least 1 decimal digit; this was a good change as it was obsoleted by the [new NumberFormat approach](https://github.com/WasabiThumb/jtoml/pull/13/files#diff-b792709427dc3bf95b1f9caa8f3093fe70e848747e84c66a3bd1d5dc9194d648R15). However, this does not mix will with the [old implementation of autoChars](https://github.com/WasabiThumb/jtoml/blob/6e9e4235c2c0c1fdd3ee735ba9ab9d59aa00c853/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java#L25) which serializes whole floats without any decimal part, counting on the now-removed code to rectify this when writing. Simply updating autoChars to not do this fixes the issue and will likely reduce similar errors in the future.