### PR TITLE
Make comment annotations repeatable

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/comment/Comment.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/comment/Comment.java
@@ -46,6 +46,7 @@ public interface Comment {
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    @Repeatable(MultiComment.Pre.class)
     @interface Pre {
         @NotNull @Pattern("^[^\\x00-\\x08\\x0A-\\x1F\\x7F]*$") String value();
     }
@@ -58,6 +59,7 @@ public interface Comment {
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    @Repeatable(MultiComment.Inline.class)
     @interface Inline {
         @NotNull @Pattern("^[^\\x00-\\x08\\x0A-\\x1F\\x7F]*$") String value();
     }
@@ -70,6 +72,7 @@ public interface Comment {
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    @Repeatable(MultiComment.Post.class)
     @interface Post {
         @NotNull @Pattern("^[^\\x00-\\x08\\x0A-\\x1F\\x7F]*$") String value();
     }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/comment/MultiComment.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/comment/MultiComment.java
@@ -1,0 +1,76 @@
+package io.github.wasabithumb.jtoml.comment;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>
+ *     Holds annotations for applying multiple comments
+ *     to values on {@link io.github.wasabithumb.jtoml.serial.TomlSerializable TomlSerializable}
+ *     classes and records, for use with the reflect serializer
+ *     ({@code jtoml-serializer-reflect}).
+ * </p>
+ * <p>
+ *     It should not be necessary to use this directly; the compiler
+ *     should generate these annotations whenever multiple single comment
+ *     annotations are present on a field.
+ * </p>
+ * <table>
+ *     <tr>
+ *         <th>Comment Class</th>
+ *         <th>Multi Comment Class</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link Comment.Pre @Comment.Pre}</td>
+ *         <td>{@link Pre @MulitComment.Pre}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link Comment.Inline @Comment.Inline}</td>
+ *         <td>{@link Inline @MulitComment.Inline}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link Comment.Post @Comment.Post}</td>
+ *         <td>{@link Post @MulitComment.Post}</td>
+ *     </tr>
+ * </table>
+ */
+@ApiStatus.Internal
+public abstract class MultiComment {
+
+    private MultiComment() { }
+
+    //
+
+    /**
+     * Variadic counterpart to {@link Comment.Pre @Comment.Pre}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    public @interface Pre {
+        @NotNull Comment.Pre @NotNull [] value();
+    }
+
+    /**
+     * Variadic counterpart to {@link Comment.Inline @Comment.Inline}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    public @interface Inline {
+        @NotNull Comment.Inline @NotNull [] value();
+    }
+
+    /**
+     * Variadic counterpart to {@link Comment.Post @Comment.Post}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+    public @interface Post {
+        @NotNull Comment.Post @NotNull [] value();
+    }
+
+}

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
@@ -2,6 +2,7 @@ package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.comment.Comments;
+import io.github.wasabithumb.jtoml.comment.MultiComment;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -17,9 +18,31 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
             @NotNull Comments comments
     ) {
         for (Annotation a : annotations) {
-            if (a instanceof Comment.Pre) comments.addPre(((Comment.Pre) a).value());
-            if (a instanceof Comment.Inline) comments.addInline(((Comment.Inline) a).value());
-            if (a instanceof Comment.Post) comments.addPost(((Comment.Post) a).value());
+            Class<?> decl = a.annotationType().getDeclaringClass();
+            if (decl == null) continue;
+            if (Comment.class.equals(decl)) {
+                if (a instanceof Comment.Pre) {
+                    comments.addPre(((Comment.Pre) a).value());
+                } else if (a instanceof Comment.Inline) {
+                    comments.addInline(((Comment.Inline) a).value());
+                } else if (a instanceof Comment.Post) {
+                    comments.addPost(((Comment.Post) a).value());
+                }
+            } else if (MultiComment.class.equals(decl)) {
+                if (a instanceof MultiComment.Pre) {
+                    for (Comment.Pre pre : ((MultiComment.Pre) a).value()) {
+                        comments.addPre(pre.value());
+                    }
+                } else if (a instanceof MultiComment.Inline) {
+                    for (Comment.Inline inline : ((MultiComment.Inline) a).value()) {
+                        comments.addInline(inline.value());
+                    }
+                } else if (a instanceof MultiComment.Post) {
+                    for (Comment.Post post : ((MultiComment.Post) a).value()) {
+                        comments.addPost(post.value());
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Enables repetition of identical comment annotations, for instance:
```java
record MyData(
     @Comment.Pre("pre comment")
     @Comment.Pre("another pre comment")
     int number
) { }
```