### PR TITLE
Fix unecessary truncation in date-time serialization

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
@@ -57,26 +57,21 @@ abstract class AbstractTomlPrimitive<T extends Serializable> implements TomlPrim
         int nano = time.getNano();
         if (nano != 0) {
             char[] buf = new char[9];
-            int digits = 0;
-            int digit;
 
-            do {
-                digit = (nano % 10);
-                if (digit != 0) {
-                    buf[digits++] = (char) (digit + '0');
-                }
+            for (int i=0; i < 9; i++) {
+                buf[8 - i] = (char) ((nano % 10) + '0');
                 nano /= 10;
-            } while (nano != 0);
+            }
+
+            int end = 9;
+            while (end > 3 && buf[end - 1] == '0') {
+                end--;
+            }
 
             sb.append('.');
 
-            for (int i=0; i < digits; i++) {
-                sb.append(buf[digits - 1 - i]);
-            }
-
-            // Pad up to 3 digits, per convention
-            for (int i=digits; i < 3; i++) {
-                sb.append('0');
+            for (int i=0; i < end; i++) {
+                sb.append(buf[i]);
             }
         }
     }

--- a/configurate/src/test/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoaderTest.java
+++ b/configurate/src/test/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoaderTest.java
@@ -115,7 +115,7 @@ class TomlConfigurationLoaderTest {
 
     @ConfigSerializable
     public static final class NativeTypesTestConfig {
-        String string ;
+        String string;
         Boolean bool;
         Integer integer;
         Float floatNum;


### PR DESCRIPTION
Fixes an issue in date-time serialization caused by a misunderstanding of the TOML specification:
> If the value contains greater precision than the implementation can support, the additional precision must be truncated, not rounded.

This remark applies to *deserialization*, which JToml has always respected. This should not affect *serialization*.
> Further precision of fractional seconds is implementation-specific.

As the ``java.time`` API supports up to nanosecond precision, the writer should also write up to nanosecond precision. This is exactly what this PR accomplishes.