### PR TITLE
Fix separators being added to floats erroneously

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/FloatTomlPrimitive.java
@@ -13,6 +13,7 @@ final class FloatTomlPrimitive extends AbstractTomlPrimitive<Double> {
         NumberFormat df = NumberFormat.getInstance(Locale.ROOT);
         df.setMaximumFractionDigits(15);
         df.setMinimumFractionDigits(1);
+        df.setGroupingUsed(false);
         return df;
     });
 

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -89,6 +89,34 @@ class JTomlTest {
         assertThrows(TomlValueException.class, () -> TOML.deserialize(PojoTable.class, table));
     }
 
+    @Test
+    void apiFloats() {
+        final TomlTable table = TomlTable.create();
+        table.put("a", 0d);
+        table.put("b", -0d);
+        table.put("c", 3.14159d);
+        table.put("d", -3.14159d);
+        table.put("e", 1e6d);
+        table.put("f", 1e6d);
+        table.put("g", 6.6743e-11d);
+        table.put("h", 6.6743e+11d);
+
+        final String expected = """
+                a = 0.0
+                b = -0.0
+                c = 3.14159
+                d = -3.14159
+                e = 1000000.0
+                f = 1000000.0
+                g = 0.000000000066743
+                h = 667430000000.0
+                """;
+
+        final String actual = assertDoesNotThrow(() -> TOML.writeToString(table));
+
+        assertEquals(expected, actual);
+    }
+
     //
 
     @TestFactory

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -97,7 +97,7 @@ class JTomlTest {
         table.put("c", 3.14159d);
         table.put("d", -3.14159d);
         table.put("e", 1e6d);
-        table.put("f", 1e6d);
+        table.put("f", -1e6d);
         table.put("g", 6.6743e-11d);
         table.put("h", 6.6743e+11d);
 
@@ -107,7 +107,7 @@ class JTomlTest {
                 c = 3.14159
                 d = -3.14159
                 e = 1000000.0
-                f = 1000000.0
+                f = -1000000.0
                 g = 0.000000000066743
                 h = 667430000000.0
                 """;


### PR DESCRIPTION
Resolves #23. Floating point values greater than 999 defined through API will no longer have commas added (violating the spec).