### PR TITLE
Add TomlArray#copyOf

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArray.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArray.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.RandomAccess;
 
 /**
@@ -27,6 +28,26 @@ public interface TomlArray extends Iterable<TomlValue>, RandomAccess, TomlValue 
     @Contract("-> new")
     static @NotNull TomlArray create() {
         return new TomlArrayImpl();
+    }
+
+    /**
+     * Creates a new mutable TomlArray with the same
+     * content as the provided array
+     */
+    @Contract("_ -> new")
+    static @NotNull TomlArray copyOf(@NotNull Iterable<? extends TomlValue> array) {
+        if (array instanceof TomlArray) {
+            return TomlArrayImpl.copyOf((TomlArrayImpl) array);
+        } else {
+            TomlArray ret;
+            if (array instanceof Collection<?>) {
+                ret = create(((Collection<?>) array).size());
+            } else {
+                ret = create();
+            }
+            ret.addAll(array);
+            return ret;
+        }
     }
 
     //

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
@@ -3,6 +3,7 @@ package io.github.wasabithumb.jtoml.value.array;
 import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.value.TomlValue;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +13,15 @@ import java.util.List;
 
 @ApiStatus.Internal
 final class TomlArrayImpl implements TomlArray {
+
+    @Contract("_ -> new")
+    static @NotNull TomlArrayImpl copyOf(@NotNull TomlArrayImpl other) {
+        TomlArrayImpl ret = new TomlArrayImpl(other.size());
+        ret.backing.addAll(other.backing);
+        return ret;
+    }
+
+    //
 
     private final List<TomlValue> backing;
     private final Comments comments;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableBranch.java
@@ -1,6 +1,7 @@
 package io.github.wasabithumb.jtoml.value.table;
 
 import io.github.wasabithumb.jtoml.value.TomlValue;
+import io.github.wasabithumb.jtoml.value.array.TomlArray;
 import org.jetbrains.annotations.*;
 
 import java.util.*;
@@ -23,8 +24,14 @@ final class TomlTableBranch implements TomlTableNode {
         TomlTableNode next;
         for (int i=0; i < branch.len; i++) {
             next = branch.nodes[i];
-            if (next.isBranch())
-                next = TomlTableBranch.copyOf(next.asBranch(), ret);
+            if (next.isBranch()) {
+                next = copyOf(next.asBranch(), ret);
+            } else {
+                TomlValue tv = next.asLeaf().value();
+                if (tv.isArray()) {
+                    next = new TomlTableLeaf(TomlArray.copyOf(tv.asArray()));
+                }
+            }
             ret.nodes[i] = next;
         }
 


### PR DESCRIPTION
Introduces an efficient ``TomlArray#copyOf`` method, similar to the existing ``TomlTable#copyOf``, which should be more efficient than copying via ``addAll``.