### PR TITLE
Remove statics in BooleanTomlPrimitive

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/BooleanTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/BooleanTomlPrimitive.java
@@ -6,14 +6,9 @@ import org.jetbrains.annotations.NotNull;
 @ApiStatus.Internal
 final class BooleanTomlPrimitive extends AbstractTomlPrimitive<Boolean> {
 
-    public static final BooleanTomlPrimitive TRUE = new BooleanTomlPrimitive(true);
-    public static final BooleanTomlPrimitive FALSE = new BooleanTomlPrimitive(false);
-
-    //
-
     private final boolean value;
 
-    private BooleanTomlPrimitive(boolean value) {
+    public BooleanTomlPrimitive(boolean value) {
         this.value = value;
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
@@ -34,7 +34,7 @@ public interface TomlPrimitive extends TomlValue {
      * wrapping the given boolean value
      */
     static @NotNull TomlPrimitive of(boolean value) {
-        return value ? BooleanTomlPrimitive.TRUE : BooleanTomlPrimitive.FALSE;
+        return new BooleanTomlPrimitive(value);
     }
 
     /**

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
@@ -33,6 +33,7 @@ public interface TomlPrimitive extends TomlValue {
      * Provides a primitive of type {@link TomlPrimitiveType#BOOLEAN BOOLEAN}
      * wrapping the given boolean value
      */
+    @Contract("_ -> new")
     static @NotNull TomlPrimitive of(boolean value) {
         return new BooleanTomlPrimitive(value);
     }


### PR DESCRIPTION
This static state can cause bugs like comment duplication during my testing.