### PR TITLE
Ignore appropriate fields in reflect serializer

### DIFF
--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -81,8 +82,11 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
     }
 
     private void keys0(@NotNull Set<TomlKey> set, @NotNull Class<?> cls) {
-        for (Field f : cls.getDeclaredFields())
+        for (Field f : cls.getDeclaredFields()) {
+            int mod = f.getModifiers();
+            if (Modifier.isStatic(mod) || Modifier.isTransient(mod)) continue;
             set.add(TomlKey.literal(f.getName()));
+        }
         cls = cls.getSuperclass();
         if (cls == null || !TomlSerializable.class.isAssignableFrom(cls)) return;
         this.keys0(set, cls);

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -69,6 +69,7 @@ class JTomlTest {
     void reflect() {
         PojoTable original = PojoTable.create();
         TomlTable toml = TOML.deserialize(PojoTable.class, original);
+        assertFalse(toml.contains("redHerring"));
         System.out.println(TOML.writeToString(toml));
         PojoTable out = TOML.serialize(PojoTable.class, toml);
         assertEquals(original, out);

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -2,6 +2,7 @@ package io.github.wasabithumb.jtoml;
 
 import io.github.wasabithumb.jtoml.comment.CommentPosition;
 import io.github.wasabithumb.jtoml.document.TomlDocument;
+import io.github.wasabithumb.jtoml.dummy.Named;
 import io.github.wasabithumb.jtoml.dummy.RecordTable;
 import io.github.wasabithumb.jtoml.except.TomlException;
 import io.github.wasabithumb.jtoml.except.TomlValueException;
@@ -71,6 +72,16 @@ class JTomlTest {
         System.out.println(TOML.writeToString(toml));
         PojoTable out = TOML.serialize(PojoTable.class, toml);
         assertEquals(original, out);
+    }
+
+    @Test
+    void finalReflect() {
+        Named original = new Named("foo");
+        TomlTable toml = TOML.deserialize(Named.class, original);
+        System.out.println(TOML.writeToString(toml));
+        Named out = TOML.serialize(Named.class, toml);
+        assertEquals(original, out);
+        assertEquals("foo", out.name());
     }
 
     @Test

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/Named.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/Named.java
@@ -1,0 +1,36 @@
+package io.github.wasabithumb.jtoml.dummy;
+
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+
+import java.util.Objects;
+
+public final class Named implements TomlSerializable {
+
+    private final String name;
+
+    private Named() {
+        this.name = null;
+    }
+
+    public Named(String name) {
+        this.name = name;
+    }
+
+    //
+
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Named other)) return false;
+        return Objects.equals(this.name, other.name);
+    }
+
+}

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
 public final class PojoTable implements TomlSerializable {
 
@@ -26,8 +27,11 @@ public final class PojoTable implements TomlSerializable {
     public LocalTime localTime;
     public LocalDateTime localDateTime;
     public OffsetDateTime offsetDateTime;
+    public transient short redHerring;
     
-    PojoTable() { }
+    PojoTable() {
+        this.redHerring = (short) ThreadLocalRandom.current().nextInt();
+    }
 
     //
 


### PR DESCRIPTION
Fixes a regression identified by #33, caused by #7. During a refactor of the reflect serializer, some logic which excluded static & transient fields from serialization was lost. This is a simple fix, but it should be covered by tests anyway. Polluting the dummy POJOs with fields to be ignored and checking for their absence may be sufficient.

This also raises a question about how final fields should be treated; the Java standard serialization library does serialize final fields and 3rd-party serializers are inconsistent about this. With some reflection magic, it is possible to ignore a field's finality (as the security manager permits). So perhaps this should be done. As it is, I believe that JToml will try but fail to serialize final fields. This should be addressed before merging as well.
