### PR TITLE
Update to 1.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ allprojects {
     apply(plugin = "java-library")
 
     group = "io.github.wasabithumb"
-    version = "1.0.0"
+    version = "1.1.0"
 
     dependencies {
         compileOnly("org.jetbrains:annotations:26.0.1")

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Key.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Key.java
@@ -1,5 +1,6 @@
 package io.github.wasabithumb.jtoml.serial.reflect;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.annotation.*;
@@ -8,7 +9,9 @@ import java.lang.annotation.*;
  * Annotation for use in {@link io.github.wasabithumb.jtoml.serial.TomlSerializable reflect serialization}.
  * Overrides the TOML key which the annotated field or record component maps to. By default, the key is
  * equal to the name of the field.
+ * @since 1.1.0
  */
+@ApiStatus.AvailableSince("1.1.0")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Key.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Key.java
@@ -1,0 +1,17 @@
+package io.github.wasabithumb.jtoml.serial.reflect;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation for use in {@link io.github.wasabithumb.jtoml.serial.TomlSerializable reflect serialization}.
+ * Overrides the TOML key which the annotated field or record component maps to. By default, the key is
+ * equal to the name of the field.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE})
+public @interface Key {
+    @NotNull String value();
+}

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
@@ -3,6 +3,7 @@ package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.key.TomlKey;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+import io.github.wasabithumb.jtoml.serial.reflect.Key;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
 import org.jetbrains.annotations.*;
 
@@ -10,10 +11,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
 
 @ApiStatus.Internal
 final class SerializableTableTypeModel<T extends TomlSerializable> extends AbstractTableTypeModel<T> {
@@ -23,12 +21,45 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
         return new SerializableTableTypeModel<>(cls.asSubclass(TomlSerializable.class));
     }
 
+    private static @NotNull Map<TomlKey, Field> buildFieldMap(@NotNull Class<?> cls) {
+        Map<TomlKey, Field> ret = new HashMap<>();
+        buildFieldMap0(cls, ret);
+        return Collections.unmodifiableMap(ret);
+    }
+
+    private static void buildFieldMap0(@NotNull Class<?> cls, @NotNull Map<TomlKey, Field> map) {
+        for (Field f : cls.getDeclaredFields()) {
+            int mod = f.getModifiers();
+            if (Modifier.isStatic(mod) || Modifier.isTransient(mod)) continue;
+            buildFieldMap00(f, map);
+        }
+        cls = cls.getSuperclass();
+        if (cls == null || !TomlSerializable.class.isAssignableFrom(cls)) return;
+        buildFieldMap0(cls, map);
+    }
+
+    private static void buildFieldMap00(@NotNull Field f, @NotNull Map<TomlKey, Field> map) {
+        String name = f.getName();
+        Key annotation = f.getAnnotation(Key.class);
+        if (annotation != null) name = annotation.value();
+        TomlKey key = TomlKey.literal(name);
+        Field existing = map.get(key);
+        if (existing != null) {
+            throw new IllegalStateException("Serializable field (" + f.getName() + ") with key " + key +
+                    " shadows field (" + existing.getName() + ") with same key declared in class " +
+                    existing.getDeclaringClass().getName());
+        }
+        map.put(key, f);
+    }
+
     //
 
     private final Class<T> type;
+    private final Map<TomlKey, Field> fieldMap;
 
     private SerializableTableTypeModel(@NotNull Class<T> type) {
         this.type = type;
+        this.fieldMap = buildFieldMap(type);
     }
 
     //
@@ -76,37 +107,18 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
 
     @Override
     public @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull T instance) {
-        Set<TomlKey> ret = new LinkedHashSet<>();
-        this.keys0(ret, this.type);
-        return Collections.unmodifiableSet(ret);
-    }
-
-    private void keys0(@NotNull Set<TomlKey> set, @NotNull Class<?> cls) {
-        for (Field f : cls.getDeclaredFields()) {
-            int mod = f.getModifiers();
-            if (Modifier.isStatic(mod) || Modifier.isTransient(mod)) continue;
-            set.add(TomlKey.literal(f.getName()));
-        }
-        cls = cls.getSuperclass();
-        if (cls == null || !TomlSerializable.class.isAssignableFrom(cls)) return;
-        this.keys0(set, cls);
+        return this.fieldMap.keySet();
     }
 
     private @NotNull Field resolveField(@NotNull TomlKey key) {
         if (key.size() != 1)
             throw new IllegalArgumentException("Illegal key size (expected 1, got " + key.size() + ")");
 
-        String k0 = key.get(0);
-        Class<?> cls = this.type;
-
-        do {
-            for (Field f : cls.getDeclaredFields()) {
-                if (k0.equals(f.getName())) return f;
-            }
-        } while ((cls = cls.getSuperclass()) != null);
+        Field ret = this.fieldMap.get(key);
+        if (ret != null) return ret;
 
         throw new IllegalArgumentException(
-                "Key \"" + k0 + "\" does not match any fields on TomlSerializable type " + this.type.getName()
+                "Key \"" + key.get(0) + "\" does not match any fields on TomlSerializable type " + this.type.getName()
         );
     }
 

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -69,8 +69,10 @@ class JTomlTest {
     void reflect() {
         PojoTable original = PojoTable.create();
         TomlTable toml = TOML.deserialize(PojoTable.class, original);
-        assertFalse(toml.contains("redHerring"));
         System.out.println(TOML.writeToString(toml));
+        assertFalse(toml.contains("redHerring"));
+        assertTrue(toml.contains("local-date"));
+        assertFalse(toml.contains("localDate"));
         PojoTable out = TOML.serialize(PojoTable.class, toml);
         assertEquals(original, out);
     }
@@ -90,6 +92,9 @@ class JTomlTest {
         RecordTable original = RecordTable.create();
         TomlTable toml = TOML.deserialize(RecordTable.class, original);
         System.out.println(TOML.writeToString(toml));
+        assertFalse(toml.contains("redHerring"));
+        assertTrue(toml.contains("local-date"));
+        assertFalse(toml.contains("localDate"));
         RecordTable out = TOML.serialize(RecordTable.class, toml);
         assertEquals(original, out);
     }

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -2,6 +2,7 @@ package io.github.wasabithumb.jtoml;
 
 import io.github.wasabithumb.jtoml.comment.CommentPosition;
 import io.github.wasabithumb.jtoml.document.TomlDocument;
+import io.github.wasabithumb.jtoml.dummy.Named;
 import io.github.wasabithumb.jtoml.dummy.RecordTable;
 import io.github.wasabithumb.jtoml.except.TomlException;
 import io.github.wasabithumb.jtoml.except.TomlValueException;
@@ -68,9 +69,20 @@ class JTomlTest {
     void reflect() {
         PojoTable original = PojoTable.create();
         TomlTable toml = TOML.deserialize(PojoTable.class, original);
+        assertFalse(toml.contains("redHerring"));
         System.out.println(TOML.writeToString(toml));
         PojoTable out = TOML.serialize(PojoTable.class, toml);
         assertEquals(original, out);
+    }
+
+    @Test
+    void finalReflect() {
+        Named original = new Named("foo");
+        TomlTable toml = TOML.deserialize(Named.class, original);
+        System.out.println(TOML.writeToString(toml));
+        Named out = TOML.serialize(Named.class, toml);
+        assertEquals(original, out);
+        assertEquals("foo", out.name());
     }
 
     @Test

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/Named.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/Named.java
@@ -1,0 +1,36 @@
+package io.github.wasabithumb.jtoml.dummy;
+
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+
+import java.util.Objects;
+
+public final class Named implements TomlSerializable {
+
+    private final String name;
+
+    private Named() {
+        this.name = null;
+    }
+
+    public Named(String name) {
+        this.name = name;
+    }
+
+    //
+
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Named other)) return false;
+        return Objects.equals(this.name, other.name);
+    }
+
+}

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
 public final class PojoTable implements TomlSerializable {
 
@@ -26,8 +27,11 @@ public final class PojoTable implements TomlSerializable {
     public LocalTime localTime;
     public LocalDateTime localDateTime;
     public OffsetDateTime offsetDateTime;
+    public transient short redHerring;
     
-    PojoTable() { }
+    PojoTable() {
+        this.redHerring = (short) ThreadLocalRandom.current().nextInt();
+    }
 
     //
 

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/PojoTable.java
@@ -3,6 +3,7 @@ package io.github.wasabithumb.jtoml.dummy;
 import io.github.wasabithumb.jtoml.Faker;
 import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+import io.github.wasabithumb.jtoml.serial.reflect.Key;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,12 +22,23 @@ public final class PojoTable implements TomlSerializable {
 
     @Comment.Inline("Some text")
     public String text;
+
     public long integer;
+
     public double decimal;
+
+    @Key("local-date")
     public LocalDate localDate;
+
+    @Key("local-time")
     public LocalTime localTime;
+
+    @Key("local-date-time")
     public LocalDateTime localDateTime;
+
+    @Key("offset-date-time")
     public OffsetDateTime offsetDateTime;
+
     public transient short redHerring;
     
     PojoTable() {

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/RecordTable.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/RecordTable.java
@@ -2,6 +2,7 @@ package io.github.wasabithumb.jtoml.dummy;
 
 import io.github.wasabithumb.jtoml.Faker;
 import io.github.wasabithumb.jtoml.comment.Comment;
+import io.github.wasabithumb.jtoml.serial.reflect.Key;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,11 +12,21 @@ import java.time.OffsetDateTime;
 public record RecordTable(
         @Comment.Inline("Some text")
         String text,
+
         long integer,
+
         double decimal,
+
+        @Key("local-date")
         LocalDate localDate,
+
+        @Key("local-time")
         LocalTime localTime,
+
+        @Key("local-date-time")
         LocalDateTime localDateTime,
+
+        @Key("offset-date-time")
         OffsetDateTime offsetDateTime
 ) {
 


### PR DESCRIPTION
- Fixed a regression in reflect serialization ([#34](https://github.com/WasabiThumb/jtoml/pull/34))
- Allow best-effort serialization of final fields (similar to Java's ``Serializable``)
- Added the ``@Key`` annotation to allow custom keys in serialization
