### PR TITLE
Publish an aggregator module

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -20,6 +20,7 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/all" />
             <option value="$PROJECT_DIR$/api" />
             <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/configurate" />

--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -1,0 +1,86 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
+plugins {
+    alias(libs.plugins.publish)
+    id("org.glavo.compile-module-info-plugin") version "2.0"
+}
+
+description = "All of JToml as a single module"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    registerFeature("configurate") {
+        usingSourceSet(sourceSets.main.get())
+    }
+    registerFeature("gson") {
+        usingSourceSet(sourceSets.main.get())
+    }
+}
+
+dependencies {
+    // Dependencies for configurate
+    "configurateApi"(platform(libs.configurate.bom))
+    "configurateApi"("org.spongepowered:configurate-core")
+
+    // Dependencies for serializer-gson
+    "gsonApi"(libs.gson)
+}
+
+// Trying to generate javadocs for the module-info is
+// cursed and will break
+tasks.javadoc {
+    exclude("**/module-info.java")
+}
+
+// Shade in all other modules
+tasks.processResources {
+    val sources = listOf(
+        project(":"),
+        project(":api"),
+        project(":internals"),
+        project(":configurate"),
+        project(":kotlin"),
+        project(":serializer-gson"),
+        project(":serializer-reflect")
+    )
+
+    sources.forEach { src ->
+        dependsOn(src.tasks.assemble)
+        from(src.layout.buildDirectory.dir("classes/java/main"))
+    }
+}
+
+//
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates("${project.group}", "jtoml-all", "${project.version}")
+    pom {
+        name.set("JToml Aggregator")
+        description.set(project.description!!)
+        inceptionYear.set("2025")
+        url.set("https://github.com/WasabiThumb/jtoml")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("wasabithumb")
+                name.set("Xavier Pedraza")
+                url.set("https://github.com/WasabiThumb/")
+            }
+        }
+        scm {
+            url.set("https://github.com/WasabiThumb/jtoml/")
+            connection.set("scm:git:git://github.com/WasabiThumb/jtoml.git")
+        }
+    }
+}

--- a/all/src/main/java/module-info.java
+++ b/all/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+module io.github.wasabithumb.jtoml {
+    exports io.github.wasabithumb.jtoml;
+    exports io.github.wasabithumb.jtoml.comment;
+    exports io.github.wasabithumb.jtoml.document;
+    exports io.github.wasabithumb.jtoml.except;
+    exports io.github.wasabithumb.jtoml.except.parse;
+    exports io.github.wasabithumb.jtoml.key;
+    exports io.github.wasabithumb.jtoml.option;
+    exports io.github.wasabithumb.jtoml.option.prop;
+    exports io.github.wasabithumb.jtoml.serial;
+    exports io.github.wasabithumb.jtoml.serial.plain;
+    exports io.github.wasabithumb.jtoml.serial.gson;
+    exports io.github.wasabithumb.jtoml.serial.reflect;
+    exports io.github.wasabithumb.jtoml.value;
+    exports io.github.wasabithumb.jtoml.value.array;
+    exports io.github.wasabithumb.jtoml.value.primitive;
+    exports io.github.wasabithumb.jtoml.value.table;
+    exports io.github.wasabithumb.jtoml.configurate;
+
+    requires static org.jetbrains.annotations;
+    requires static com.google.gson;
+    requires static org.spongepowered.configurate;
+    uses org.spongepowered.configurate.loader.ConfigurationFormat;
+}

--- a/configurate/build.gradle.kts
+++ b/configurate/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 dependencies {
     implementation(project(":"))
     api(project(":api"))
-    api(platform("org.spongepowered:configurate-bom:4.2.0"))
+    api(platform(libs.configurate.bom))
     api("org.spongepowered:configurate-core")
 
     testImplementation(project(":internals:test-utils"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,12 @@
 [versions]
 junit = "5.7.1"
+gson = "2.13.1"
+configurate = "4.2.0"
 
 [libraries]
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+configurate-bom = { group = "org.spongepowered", name = "configurate-bom", version.ref = "configurate" }
 
 [plugins]
 jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.21" }

--- a/serializer-gson/build.gradle.kts
+++ b/serializer-gson/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation(project(":api"))
-    implementation("com.google.code.gson:gson:2.13.1")
+    api(libs.gson)
 }
 
 //

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 rootProject.name = "jtoml"
 include(
+    ":all",
     ":api",
     ":internals",
    ":internals:test-utils",


### PR DESCRIPTION
Would resolve #36. Introduces ``jtoml-all`` which includes *all* of JToml, optionally depends on their transitive dependencies (currently Gson and Configurate), and packages a ``module-info.java`` for JPMS compatibility.