### PR TITLE
Improvements to serialization API clarity

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
@@ -172,8 +172,22 @@ public interface JToml {
      * @param type The type to serialize to
      * @param table The table to serialize
      * @throws IllegalArgumentException No serializer is registered for the given type
+     * @deprecated Use {@link #fromToml(Class, TomlTable)}
      */
-    <T> @NotNull T serialize(@NotNull Class<T> type, @NotNull TomlTable table) throws IllegalArgumentException;
+    @Deprecated
+    default <T> @NotNull T serialize(@NotNull Class<T> type, @NotNull TomlTable table) throws IllegalArgumentException {
+        return this.fromToml(type, table);
+    }
+
+    /**
+     * Converts the given TOML table to the given type,
+     * if an appropriate serializer is present in the classpath.
+     * A list of serializers can be found {@link io.github.wasabithumb.jtoml.serial.TomlSerializer here}.
+     * @param type The type to convert to
+     * @param table The table to convert
+     * @throws IllegalArgumentException No serializer is registered for the given type
+     */
+    <T> @NotNull T fromToml(@NotNull Class<T> type, @NotNull TomlTable table) throws IllegalArgumentException;
 
     /**
      * Deserializes a given TOML table from the given type,
@@ -182,7 +196,22 @@ public interface JToml {
      * @param type The type to deserialize from
      * @param data The data to deserialize into a TOML table
      * @throws IllegalArgumentException No deserializer is registered for the given type
+     * @deprecated Use {@link #toToml(Class, Object)}
      */
-    <T> @NotNull TomlTable deserialize(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException;
+    @Deprecated
+    default <T> @NotNull TomlTable deserialize(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException {
+        return this.toToml(type, data);
+    }
+
+    /**
+     * Converts the given type to a TOML table,
+     * if an appropriate deserializer is present in the classpath.
+     * A list of serializers can be found {@link io.github.wasabithumb.jtoml.serial.TomlSerializer here}.
+     * @param type The type to convert from
+     * @param data The data to convert into a TOML table
+     * @throws IllegalArgumentException No deserializer is registered for the given type
+     */
+    <T> @NotNull TomlTable toToml(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException;
+
 
 }

--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializer.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializer.java
@@ -47,9 +47,25 @@ public interface TomlSerializer<I, O> {
     @ApiStatus.OverrideOnly
     @NotNull Class<O> outType();
 
+    /**
+     * @deprecated Use {@link #fromToml(TomlTable)}
+     */
+    @Deprecated
     @NotNull O serialize(@NotNull TomlTable table);
 
+    default @NotNull O fromToml(@NotNull TomlTable table) {
+        return this.serialize(table);
+    }
+
+    /**
+     * @deprecated Use {@link #toToml(Object)}
+     */
+    @Deprecated
     @NotNull TomlTable deserialize(@NotNull I data);
+
+    default @NotNull TomlTable toToml(@NotNull I data) {
+        return this.deserialize(data);
+    }
 
     //
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializerService.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/TomlSerializerService.java
@@ -1,11 +1,8 @@
 package io.github.wasabithumb.jtoml.serial;
 
 import io.github.wasabithumb.jtoml.JToml;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-@ApiStatus.Internal
-@ApiStatus.NonExtendable
 public abstract class TomlSerializerService {
 
     public abstract boolean canSerializeTo(@NotNull Class<?> outType);

--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
@@ -23,13 +23,23 @@ public final class PlainTextTomlSerializer implements TomlSerializer.Symmetric<S
     }
 
     @Override
-    public @NotNull String serialize(@NotNull TomlTable table) {
+    public @NotNull String fromToml(@NotNull TomlTable table) {
         return this.instance.writeToString(table);
     }
 
     @Override
-    public @NotNull TomlTable deserialize(@NotNull String data) {
+    public @NotNull TomlTable toToml(@NotNull String data) {
         return this.instance.readFromString(data);
+    }
+
+    @Override
+    public @NotNull String serialize(@NotNull TomlTable table) {
+        return this.fromToml(table);
+    }
+
+    @Override
+    public @NotNull TomlTable deserialize(@NotNull String data) {
+        return this.toToml(data);
     }
 
 }

--- a/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
+++ b/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
@@ -79,13 +79,13 @@ object KToml : JToml {
     }
 
     @Throws(TomlException::class)
-    override fun <T : Any> serialize(type: Class<T>, table: TomlTable): T {
-        return this.instance.serialize(type, table)
+    override fun <T : Any> fromToml(type: Class<T>, table: TomlTable): T {
+        return this.instance.fromToml(type, table)
     }
 
     @Throws(TomlException::class)
-    override fun <T : Any> deserialize(type: Class<T>, data: T): TomlTable {
-        return this.instance.deserialize(type, data)
+    override fun <T : Any> toToml(type: Class<T>, data: T): TomlTable {
+        return this.instance.toToml(type, data)
     }
 
 }
@@ -93,9 +93,28 @@ object KToml : JToml {
 // Serialization
 
 /**
+ * Converts the given TOML table to the given type,
+ * if an appropriate serializer is present in the classpath
+ */
+@Throws(TomlException::class, IllegalArgumentException::class)
+fun <T: Any> JToml.fromToml(type: KClass<T>, table: TomlTable): T {
+    return this.fromToml(type.java, table)
+}
+
+/**
+ * Converts the given object to a TOML table,
+ * if an appropriate deserializer is present in the classpath
+ */
+@Throws(TomlException::class, IllegalArgumentException::class)
+fun <T: Any> JToml.toToml(type: KClass<T>, data: T): TomlTable {
+    return this.toToml(type.java, data)
+}
+
+/**
  * Serializes the given TOML table to the given type,
  * if an appropriate serializer is present in the classpath
  */
+@Deprecated("Replaced by fromToml")
 @Throws(TomlException::class, IllegalArgumentException::class)
 fun <T: Any> JToml.serialize(type: KClass<T>, table: TomlTable): T {
     return this.serialize(type.java, table)
@@ -105,6 +124,7 @@ fun <T: Any> JToml.serialize(type: KClass<T>, table: TomlTable): T {
  * Deserializes a TOML table from the given type,
  * if an appropriate deserializer is present in the classpath
  */
+@Deprecated("Replaced by toToml")
 @Throws(TomlException::class, IllegalArgumentException::class)
 fun <T: Any> JToml.deserialize(type: KClass<T>, data: T): TomlTable {
     return this.deserialize(type.java, data)

--- a/serializer-gson/src/main/java/io/github/wasabithumb/jtoml/serial/gson/GsonTomlSerializer.java
+++ b/serializer-gson/src/main/java/io/github/wasabithumb/jtoml/serial/gson/GsonTomlSerializer.java
@@ -36,7 +36,7 @@ public final class GsonTomlSerializer implements TomlSerializer.Symmetric<JsonOb
     }
 
     @Override
-    public @NotNull JsonObject serialize(@NotNull TomlTable table) {
+    public @NotNull JsonObject fromToml(@NotNull TomlTable table) {
         JsonObject ret = new JsonObject();
         TomlValue value;
         for (TomlKey key : table.keys(false)) {
@@ -48,7 +48,7 @@ public final class GsonTomlSerializer implements TomlSerializer.Symmetric<JsonOb
     }
 
     @Override
-    public @NotNull TomlTable deserialize(@NotNull JsonObject data) {
+    public @NotNull TomlTable toToml(@NotNull JsonObject data) {
         TomlTable ret = TomlTable.create();
         String key;
         JsonElement value;
@@ -60,11 +60,21 @@ public final class GsonTomlSerializer implements TomlSerializer.Symmetric<JsonOb
         return ret;
     }
 
+    @Override
+    public @NotNull JsonObject serialize(@NotNull TomlTable table) {
+        return this.fromToml(table);
+    }
+
+    @Override
+    public @NotNull TomlTable deserialize(@NotNull JsonObject data) {
+        return this.toToml(data);
+    }
+
     //
 
     private @NotNull JsonElement serializeValue(@NotNull TomlValue value) {
         if (value.isTable()) {
-            return this.serialize(value.asTable());
+            return this.fromToml(value.asTable());
         } else if (value.isArray()) {
             TomlArray tomlArray = value.asArray();
             JsonArray array = new JsonArray(tomlArray.size());
@@ -96,7 +106,7 @@ public final class GsonTomlSerializer implements TomlSerializer.Symmetric<JsonOb
             for (JsonElement el : jsonArray) array.add(this.deserializeElement(el));
             return array;
         } else if (value.isJsonObject()) {
-            return this.deserialize(value.getAsJsonObject());
+            return this.toToml(value.getAsJsonObject());
         } else {
             return this.deserializePrimitive(value.getAsJsonPrimitive());
         }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -31,7 +31,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
     }
 
     @Override
-    public @NotNull T serialize(@NotNull TomlTable table) {
+    public @NotNull T fromToml(@NotNull TomlTable table) {
         return this.serializeTable(
                 this.model,
                 table
@@ -39,7 +39,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
     }
 
     @Override
-    public @NotNull TomlTable deserialize(@NotNull T data) {
+    public @NotNull TomlTable toToml(@NotNull T data) {
         ReferenceHolder parents = new ReferenceHolder();
         parents.add(this);
         return this.deserializeTable(
@@ -47,6 +47,16 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
                 this.model,
                 data
         );
+    }
+
+    @Override
+    public @NotNull T serialize(@NotNull TomlTable table) {
+        return this.fromToml(table);
+    }
+
+    @Override
+    public @NotNull TomlTable deserialize(@NotNull T data) {
+        return this.toToml(data);
     }
 
     //

--- a/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
+++ b/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
@@ -112,13 +112,13 @@ final class JTomlImpl implements JToml {
     //
 
     @Override
-    public <T> @NotNull T serialize(@NotNull Class<T> type, @NotNull TomlTable table) throws IllegalArgumentException {
+    public <T> @NotNull T fromToml(@NotNull Class<T> type, @NotNull TomlTable table) throws IllegalArgumentException {
         int count = 0;
         for (TomlSerializerService service : SERIALIZERS) {
             count++;
             if (service.canSerializeTo(type)) {
                 TomlSerializer<?, T> s = service.getSerializer(this, type);
-                return s.serialize(table);
+                return s.fromToml(table);
             }
         }
         throw new IllegalArgumentException(
@@ -128,13 +128,13 @@ final class JTomlImpl implements JToml {
     }
 
     @Override
-    public @NotNull <T> TomlTable deserialize(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException {
+    public @NotNull <T> TomlTable toToml(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException {
         int count = 0;
         for (TomlSerializerService service : SERIALIZERS) {
             count++;
             if (service.canDeserializeFrom(type)) {
                 TomlSerializer<T, ?> d = service.getDeserializer(this, type);
-                return d.deserialize(data);
+                return d.toToml(data);
             }
         }
         throw new IllegalArgumentException(

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -68,21 +68,21 @@ class JTomlTest {
     @Test
     void reflect() {
         PojoTable original = PojoTable.create();
-        TomlTable toml = TOML.deserialize(PojoTable.class, original);
+        TomlTable toml = TOML.toToml(PojoTable.class, original);
         System.out.println(TOML.writeToString(toml));
         assertFalse(toml.contains("redHerring"));
         assertTrue(toml.contains("local-date"));
         assertFalse(toml.contains("localDate"));
-        PojoTable out = TOML.serialize(PojoTable.class, toml);
+        PojoTable out = TOML.fromToml(PojoTable.class, toml);
         assertEquals(original, out);
     }
 
     @Test
     void finalReflect() {
         Named original = new Named("foo");
-        TomlTable toml = TOML.deserialize(Named.class, original);
+        TomlTable toml = TOML.toToml(Named.class, original);
         System.out.println(TOML.writeToString(toml));
-        Named out = TOML.serialize(Named.class, toml);
+        Named out = TOML.fromToml(Named.class, toml);
         assertEquals(original, out);
         assertEquals("foo", out.name());
     }
@@ -90,12 +90,12 @@ class JTomlTest {
     @Test
     void recordReflect() {
         RecordTable original = RecordTable.create();
-        TomlTable toml = TOML.deserialize(RecordTable.class, original);
+        TomlTable toml = TOML.toToml(RecordTable.class, original);
         System.out.println(TOML.writeToString(toml));
         assertFalse(toml.contains("redHerring"));
         assertTrue(toml.contains("local-date"));
         assertFalse(toml.contains("localDate"));
-        RecordTable out = TOML.serialize(RecordTable.class, toml);
+        RecordTable out = TOML.fromToml(RecordTable.class, toml);
         assertEquals(original, out);
     }
 
@@ -103,7 +103,7 @@ class JTomlTest {
     void badDateTime() {
         PojoTable table = PojoTable.create();
         table.localDate = LocalDate.of(-1, 7, 16); // year -1
-        assertThrows(TomlValueException.class, () -> TOML.deserialize(PojoTable.class, table));
+        assertThrows(TomlValueException.class, () -> TOML.toToml(PojoTable.class, table));
     }
 
     @Test


### PR DESCRIPTION
Will resolve #40. Aliases ``serialize``/``deserialize`` methods throughout the library with ``fromToml``/``toToml`` and deprecates the former.