### PR TITLE
Fix pre/post comments being duplicated in certain cases

### DIFF
--- a/internals/src/main/java/io/github/wasabithumb/jtoml/expression/Expression.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/expression/Expression.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public interface Expression {
 
     static @NotNull EmptyExpression empty() {
-        return EmptyExpression.INSTANCE;
+        return new EmptyExpression();
     }
 
     static @NotNull KeyValueExpression keyValue(@NotNull TomlKey key, @NotNull TomlValue value) {

--- a/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -1,6 +1,8 @@
 package io.github.wasabithumb.jtoml;
 
+import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.comment.CommentPosition;
+import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.document.TomlDocument;
 import io.github.wasabithumb.jtoml.dummy.Named;
 import io.github.wasabithumb.jtoml.dummy.RecordTable;
@@ -132,6 +134,37 @@ class JTomlTest {
         final String actual = assertDoesNotThrow(() -> TOML.writeToString(table));
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void comments() {
+        // https://github.com/WasabiThumb/jtoml/issues/44
+        final String src = """
+                # a
+                [a]
+                
+                # b
+                [b]
+                """;
+
+        TomlDocument doc = JToml.jToml()
+                .readFromString(src);
+
+        TomlValue a = doc.get("a");
+        assertNotNull(a);
+        Comments ac = a.comments();
+        assertEquals(1, ac.count());
+        List<Comment> acPre = ac.get(CommentPosition.PRE);
+        assertEquals(1, acPre.size());
+        assertEquals("a", acPre.get(0).content());
+
+        TomlValue b = doc.get("b");
+        assertNotNull(b);
+        Comments bc = b.comments();
+        assertEquals(1, bc.count());
+        List<Comment> bcPre = bc.get(CommentPosition.PRE);
+        assertEquals(1, bcPre.size());
+        assertEquals("b", bcPre.get(0).content());
     }
 
     //


### PR DESCRIPTION
Resolves #44. The expression system predates comment parsing, and at the time of its implementation, having the empty expression be a singleton made sense. However, with the introduction of comment parsing, this empty expression singleton became mutable (satanic) causing comments to get duplicated.