### PR TITLE
Improve Configurate integration

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/TomlPrimitive.java
@@ -213,6 +213,18 @@ public interface TomlPrimitive extends TomlValue {
         }
     }
 
+    /**
+     * Parses a float string into a
+     * {@link TomlPrimitive} with type {@link TomlPrimitiveType#FLOAT FLOAT}.
+     * @throws NullPointerException Provided string is null
+     * @throws IllegalArgumentException Provided string is not a valid float
+     */
+    @Contract("null -> fail; _ -> new")
+    static @NotNull TomlPrimitive parseFloat(String string) throws IllegalArgumentException {
+        if (string == null) throw new NullPointerException("Cannot parse null as float");
+        return FloatTomlPrimitive.parse(string);
+    }
+
     //
 
     /**

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationFormat.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationFormat.java
@@ -2,7 +2,7 @@ package io.github.wasabithumb.jtoml.configurate;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.framework.qual.DefaultQualifier;
-import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.loader.AbstractConfigurationFormat;
 import org.spongepowered.configurate.loader.ConfigurationFormat;
 import org.spongepowered.configurate.util.UnmodifiableCollections;
@@ -17,7 +17,7 @@ import java.util.Set;
  */
 @DefaultQualifier(NonNull.class)
 public final class TomlConfigurationFormat extends AbstractConfigurationFormat<
-        BasicConfigurationNode,
+        CommentedConfigurationNode,
         TomlConfigurationLoader,
         TomlConfigurationLoader.Builder
         > {

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
@@ -76,6 +76,12 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<C
             .inheritable(false)
             .build();
 
+    @ApiStatus.Internal
+    public static final RepresentationHint<String> FLOAT_FORM = RepresentationHint.of(
+            "configurate:toml/float-form",
+            String.class
+    );
+
     /**
      * Creates a new {@link TomlConfigurationLoader.Builder}.
      *
@@ -155,6 +161,7 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<C
                     break;
                 case FLOAT:
                     node.raw(primitive.asDouble());
+                    node.hint(FLOAT_FORM, primitive.asString());
                     break;
                 case OFFSET_DATE_TIME:
                     node.raw(primitive.asOffsetDateTime());
@@ -235,6 +242,8 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<C
             } else if (value instanceof Integer || value instanceof Long) {
                 return TomlPrimitive.of(((Number) value).longValue());
             } else if (value instanceof Float || value instanceof Double) {
+                final @Nullable String form = child.hint(FLOAT_FORM);
+                if (form != null) return TomlPrimitive.parseFloat(form);
                 return TomlPrimitive.of(((Number) value).doubleValue());
             } else if (value instanceof Number) {
                 return TomlPrimitive.of(((Number) value).longValue());

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoader.java
@@ -69,10 +69,12 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<C
             .serializers(TOML_SERIALIZERS);
 
     @ApiStatus.Internal
-    public static final RepresentationHint<CommentForm> COMMENT_FORM = RepresentationHint.of(
-            "configurate:toml/comment-form",
-            CommentForm.class
-    );
+    public static final RepresentationHint<CommentForm> COMMENT_FORM = RepresentationHint.<CommentForm>builder()
+            .identifier("configurate:toml/comment-form")
+            .valueType(CommentForm.class)
+            .defaultValue(CommentForm.DEFAULT)
+            .inheritable(false)
+            .build();
 
     /**
      * Creates a new {@link TomlConfigurationLoader.Builder}.
@@ -258,21 +260,8 @@ public final class TomlConfigurationLoader extends AbstractConfigurationLoader<C
             final String[] lines = comment.split("\n");
 
             final @Nullable CommentForm form = node.hint(COMMENT_FORM);
-            if (form != null) {
-                for (int i = 0; i < lines.length; i++) {
-                    if (i < form.pre()) {
-                        comments.addPre(lines[i]);
-                    } else if (i == form.pre() && form.inline()) {
-                        comments.addInline(lines[i]);
-                    } else {
-                        comments.addPost(lines[i]);
-                    }
-                }
-            } else {
-                for (String line : lines) {
-                    comments.addPre(line);
-                }
-            }
+            assert form != null;
+            form.apply(lines, comments);
         }
     }
 

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/hint/CommentForm.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/hint/CommentForm.java
@@ -10,22 +10,36 @@ import java.util.Objects;
 @ApiStatus.Internal
 public final class CommentForm {
 
+    public static final CommentForm DEFAULT = new CommentForm(Integer.MAX_VALUE, false);
+
+    //
+
     private final int pre;
     private final boolean inline;
 
+    private CommentForm(int pre, boolean inline) {
+        this.pre = pre;
+        this.inline = inline;
+    }
+
     public CommentForm(@NotNull Comments comments) {
-        this.pre = comments.get(CommentPosition.PRE).size();
-        this.inline = comments.getInline() != null;
+        this(comments.get(CommentPosition.PRE).size(), comments.getInline() != null);
     }
 
     //
 
-    public int pre() {
-        return this.pre;
-    }
-
-    public boolean inline() {
-        return this.inline;
+    public void apply(@NotNull String @NotNull [] src, @NotNull Comments dest) {
+        String line;
+        for (int i = 0; i < src.length; i++) {
+            line = src[i];
+            if (i < this.pre) {
+                dest.addPre(line);
+            } else if (i == this.pre && this.inline) {
+                dest.addInline(line);
+            } else {
+                dest.addPost(line);
+            }
+        }
     }
 
     @Override

--- a/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/hint/CommentForm.java
+++ b/configurate/src/main/java/io/github/wasabithumb/jtoml/configurate/hint/CommentForm.java
@@ -1,0 +1,44 @@
+package io.github.wasabithumb.jtoml.configurate.hint;
+
+import io.github.wasabithumb.jtoml.comment.CommentPosition;
+import io.github.wasabithumb.jtoml.comment.Comments;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+@ApiStatus.Internal
+public final class CommentForm {
+
+    private final int pre;
+    private final boolean inline;
+
+    public CommentForm(@NotNull Comments comments) {
+        this.pre = comments.get(CommentPosition.PRE).size();
+        this.inline = comments.getInline() != null;
+    }
+
+    //
+
+    public int pre() {
+        return this.pre;
+    }
+
+    public boolean inline() {
+        return this.inline;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.pre, this.inline);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CommentForm)) return false;
+        CommentForm other = (CommentForm) obj;
+        return this.pre == other.pre &&
+                this.inline == other.inline;
+    }
+
+}

--- a/configurate/src/test/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoaderTest.java
+++ b/configurate/src/test/java/io/github/wasabithumb/jtoml/configurate/TomlConfigurationLoaderTest.java
@@ -6,7 +6,7 @@ import io.github.wasabithumb.jtoml.option.prop.LineSeparator;
 import io.leangen.geantyref.TypeToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.spongepowered.configurate.BasicConfigurationNode;
+import org.spongepowered.configurate.CommentedConfigurationNode;
 import org.spongepowered.configurate.ConfigurateException;
 import org.spongepowered.configurate.ConfigurationNode;
 import org.spongepowered.configurate.loader.ConfigurationLoader;
@@ -39,7 +39,7 @@ class TomlConfigurationLoaderTest {
     @Test
     void testSimpleLoading() throws ConfigurateException {
         final URL url = this.getClass().getResource("/example.toml");
-        final ConfigurationLoader<BasicConfigurationNode> loader = TomlConfigurationLoader.builder()
+        final ConfigurationLoader<CommentedConfigurationNode> loader = TomlConfigurationLoader.builder()
                 .url(url).build();
         final ConfigurationNode node = loader.load();
         assertEquals("unicorn", node.node("test", "op-level").raw());
@@ -54,7 +54,7 @@ class TomlConfigurationLoaderTest {
 
     @Test
     void testReadWithTabs() throws ConfigurateException {
-        final ConfigurationNode expected = BasicConfigurationNode.root(n -> {
+        final ConfigurationNode expected = CommentedConfigurationNode.root(n -> {
             n.node("document").act(d -> {
                 d.node("we").raw("support tabs");
                 d.node("and").raw("literal tabs\tin strings");
@@ -66,7 +66,7 @@ class TomlConfigurationLoaderTest {
         });
 
         final URL url = this.getClass().getResource("/tab-example.toml");
-        final ConfigurationLoader<BasicConfigurationNode> loader = TomlConfigurationLoader.builder()
+        final ConfigurationLoader<CommentedConfigurationNode> loader = TomlConfigurationLoader.builder()
                 .url(url).build();
         final ConfigurationNode node = loader.load();
         assertEquals(expected, node);
@@ -75,7 +75,7 @@ class TomlConfigurationLoaderTest {
     @Test
     void testWriteBasicFile(final @TempDir Path tempDir) throws ConfigurateException, IOException {
         final Path target = tempDir.resolve("write-basic.toml");
-        final ConfigurationNode node = BasicConfigurationNode.root(n -> {
+        final ConfigurationNode node = CommentedConfigurationNode.root(n -> {
             n.node("mapping", "first").set("hello");
             n.node("mapping", "second").set("world");
 
@@ -100,12 +100,12 @@ class TomlConfigurationLoaderTest {
     @Test
     void nativeTypesRoundTrip(final @TempDir Path tempDir) throws IOException {
         final Path target = tempDir.resolve("native-types.toml");
-        final ConfigurationLoader<BasicConfigurationNode> loader = TomlConfigurationLoader.builder()
+        final ConfigurationLoader<CommentedConfigurationNode> loader = TomlConfigurationLoader.builder()
                 .path(target)
                 .set(JTomlOption.LINE_SEPARATOR, LineSeparator.LF)
                 .build();
 
-        final BasicConfigurationNode node = loader.load();
+        final CommentedConfigurationNode node = loader.load();
         final NativeTypesTestConfig data = Faker.create(NativeTypesTestConfig.class);
         node.set(data);
         loader.save(node);


### PR DESCRIPTION
Modifies ``TomlConfigurationFormat`` to produce ``CommentedConfigurationNode``s instead of ``BasicConfigurationNode``s and to read/write comments. This involves some sacrifices (Configurate's api demands that our pre and inline comments share the same ``String``, separated by ``\n``). Must ensure that these changes are safe before merging.