### PR TITLE
Add option to sort keys by creation time

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/option/JTomlOption.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/option/JTomlOption.java
@@ -99,6 +99,12 @@ public interface JTomlOption<T> {
     @ApiStatus.AvailableSince("0.6.0")
     JTomlOption<ArrayStrategy> ARRAY_STRATEGY = of("ARRAY_STRATEGY", ArrayStrategy.class, ArrayStrategy.DYNAMIC);
 
+    /**
+     * Determines how keys are sorted within a table
+     * when writing.
+     */
+    JTomlOption<SortMethod> SORTING = of("SORTING", SortMethod.class, SortMethod.STRATIFIED);
+
     //
 
     /**

--- a/api/src/main/java/io/github/wasabithumb/jtoml/option/prop/SortMethod.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/option/prop/SortMethod.java
@@ -1,0 +1,33 @@
+package io.github.wasabithumb.jtoml.option.prop;
+
+/**
+ * Determines how keys within a table
+ * are sorted when writing.
+ * @see #STRATIFIED
+ * @see #LEXICOGRAPHICAL
+ * @see #TIME
+ */
+public enum SortMethod {
+    /**
+     * Groups keys by value type: first primitives,
+     * then arrays, then arrays-of-tables, then tables.
+     * This ensures that arrays-of-tables and tables are
+     * never forced to use inline syntax.
+     */
+    STRATIFIED,
+
+    /**
+     * Keys are sorted by identity, resulting
+     * in a lexicographical order.
+     * This may force arrays-of-tables and tables to use inline
+     * syntax in order to produce valid TOML.
+     */
+    LEXICOGRAPHICAL,
+
+    /**
+     * Keys are sorted by creation time.
+     * This may force arrays-of-tables and tables to use inline
+     * syntax in order to produce valid TOML.
+     */
+    TIME;
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/TomlValue.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/TomlValue.java
@@ -39,6 +39,12 @@ public interface TomlValue {
     //
 
     /**
+     * Reports the time that this object was created
+     * as reported by {@link System#nanoTime()}.
+     */
+    long creationTime();
+
+    /**
      * Reports the flags stored on this value.
      * Flags are opaque to consumers but have internal meaning
      * required for spec-compliant reading.

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/array/TomlArrayImpl.java
@@ -34,11 +34,13 @@ final class TomlArrayImpl implements TomlArray {
 
     //
 
+    private final long creationTime;
     private final List<TomlValue> backing;
     private final Comments comments;
     private transient byte flags;
 
     private TomlArrayImpl(int initialCapacity, @NotNull Comments comments) {
+        this.creationTime = System.nanoTime();
         this.backing = new ArrayList<>(initialCapacity);
         this.comments = comments;
         this.flags = 0;
@@ -54,6 +56,10 @@ final class TomlArrayImpl implements TomlArray {
 
     //
 
+    @Override
+    public long creationTime() {
+        return this.creationTime;
+    }
 
     @Override
     public int flags() {

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
@@ -79,16 +79,22 @@ abstract class AbstractTomlPrimitive<T extends Serializable> implements TomlPrim
 
     //
 
+    protected final long creationTime;
     protected final Comments comments;
     protected transient byte flags;
 
     protected AbstractTomlPrimitive(@NotNull Comments comments) {
+        this.creationTime = System.nanoTime();
         this.comments = comments;
         this.flags = (byte) 0;
     }
 
     //
 
+    @Override
+    public long creationTime() {
+        return this.creationTime;
+    }
 
     @Override
     public int flags() {

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/table/TomlTableImpl.java
@@ -19,11 +19,13 @@ final class TomlTableImpl implements TomlTable {
 
     //
 
+    private final long creationTime;
     private final TomlTableBranch root;
     private final Comments comments;
     private transient byte flags;
 
     private TomlTableImpl(@NotNull TomlTableBranch root, @NotNull Comments comments) {
+        this.creationTime = System.nanoTime();
         this.root = root;
         this.comments = comments;
         this.flags = 0;
@@ -38,7 +40,11 @@ final class TomlTableImpl implements TomlTable {
     }
 
     //
-
+    
+    @Override
+    public long creationTime() {
+        return this.creationTime;
+    }
 
     @Override
     public int flags() {

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/document/TomlDocumentImpl.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/document/TomlDocumentImpl.java
@@ -14,10 +14,12 @@ import java.util.Set;
 @ApiStatus.Internal
 public final class TomlDocumentImpl implements TomlDocument {
 
+    private final long creationTime;
     private final TomlTable backing;
     private boolean orderMarked = false;
 
     public TomlDocumentImpl(@NotNull TomlTable backing) {
+        this.creationTime = System.nanoTime();
         this.backing = backing;
     }
 
@@ -34,6 +36,11 @@ public final class TomlDocumentImpl implements TomlDocument {
     // END Metadata
 
     // START Super
+
+    @Override
+    public long creationTime() {
+        return this.creationTime;
+    }
 
     @Override
     public int flags() {


### PR DESCRIPTION
Partially solves #49. This is a table-level sorting mechanism that may produce more intuitive results for some consumers. As an example:
```java
JToml toml = JToml.jToml(JTomlOptions.builder()
        .set(JTomlOption.SORTING, SortMethod.TIME)
        .build());

TomlTable table = TomlTable.create();
table.put("z", 1);                  // appears 1st
table.put("x", TomlTable.create()); // appears 2nd; this is forced to use inline table syntax
table.put("y", 3);                  // appears 3rd
table.put("q", TomlTable.create()); // appears 4th; this uses normal table syntax

String string = toml.writeToString(table);
```

The default sort method is ``STRATIFIED`` which works identically to the current behavior.