### PR TITLE
Allow for anonymous serialization

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
@@ -215,5 +215,12 @@ public interface JToml {
     @ApiStatus.AvailableSince("1.2.1")
     <T> @NotNull TomlTable toToml(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException;
 
+    /**
+     * Converts the given object to a TOML table.
+     * Defers to {@link #toToml(Class, Object)} internally.
+     * @param data The object to convert
+     * @throws IllegalArgumentException No known deserializer can handle objects of the given type
+     */
+    @NotNull TomlTable toToml(@NotNull Object data) throws IllegalArgumentException;
 
 }

--- a/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
+++ b/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
@@ -88,6 +88,11 @@ object KToml : JToml {
         return this.instance.toToml(type, data)
     }
 
+    @Throws(TomlException::class)
+    override fun toToml(data: Any): TomlTable {
+        return this.instance.toToml(data)
+    }
+
 }
 
 // Serialization

--- a/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
+++ b/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
@@ -129,12 +129,21 @@ final class JTomlImpl implements JToml {
 
     @Override
     public @NotNull <T> TomlTable toToml(@NotNull Class<T> type, @NotNull T data) throws IllegalArgumentException {
+        return this.toTomlUnsafe(type, data);
+    }
+
+    @Override
+    public @NotNull TomlTable toToml(@NotNull Object data) throws IllegalArgumentException {
+        return this.toTomlUnsafe(data.getClass(), data);
+    }
+
+    private <T> @NotNull TomlTable toTomlUnsafe(@NotNull Class<T> type, @NotNull Object data) throws IllegalArgumentException {
         int count = 0;
         for (TomlSerializerService service : SERIALIZERS) {
             count++;
             if (service.canDeserializeFrom(type)) {
                 TomlSerializer<T, ?> d = service.getDeserializer(this, type);
-                return d.toToml(data);
+                return d.toToml(type.cast(data));
             }
         }
         throw new IllegalArgumentException(


### PR DESCRIPTION
Adds a ``toToml`` overload which does not require an object type, rather inferring it from the provided object. This prevents API consumers from having to perform unchecked operations or create wrappers to marshal objects of unknown type.