### PR TITLE
Formally expose serializers

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/serial/plain/PlainTextTomlSerializer.java
@@ -3,14 +3,27 @@ package io.github.wasabithumb.jtoml.serial.plain;
 import io.github.wasabithumb.jtoml.JToml;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-@ApiStatus.Internal
+/**
+ * A bare-bones serializer which uses a
+ * {@link JToml} instance to convert
+ * a TOML table to/from a {@link String}.
+ * The {@link #fromToml(TomlTable) fromToml} method is
+ * identical to {@link JToml#writeToString(TomlTable) writeToString}
+ * and the {@link #toToml(String) toToml} method is
+ * identical to {@link JToml#readFromString(String) readFromString}.
+ */
 public final class PlainTextTomlSerializer implements TomlSerializer.Symmetric<String> {
 
     private final JToml instance;
 
+    /**
+     * Creates a new plain text serializer,
+     * deferring to the given {@link JToml} instance's
+     * {@link JToml#readFromString(String) readFromString} and {@link JToml#writeToString(TomlTable) writeToString}
+     * methods.
+     */
     public PlainTextTomlSerializer(@NotNull JToml instance) {
         this.instance = instance;
     }

--- a/serializer-gson/src/main/java/io/github/wasabithumb/jtoml/serial/gson/GsonTomlSerializer.java
+++ b/serializer-gson/src/main/java/io/github/wasabithumb/jtoml/serial/gson/GsonTomlSerializer.java
@@ -15,10 +15,21 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
+/**
+ * Serializer leveraging the Gson API to convert
+ * TOML tables to/from JSON objects.
+ * @see #instance()
+ * @see #fromToml(TomlTable)
+ * @see #toToml(JsonObject)
+ */
 public final class GsonTomlSerializer implements TomlSerializer.Symmetric<JsonObject> {
 
     private static final GsonTomlSerializer DEFAULT_INSTANCE = new GsonTomlSerializer();
 
+    /**
+     * Provides the global singleton
+     * instance of {@link GsonTomlSerializer}.
+     */
     @Contract(pure = true)
     public static @NotNull GsonTomlSerializer instance() {
         return DEFAULT_INSTANCE;

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -151,11 +151,11 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
             @NotNull TypeModel<E> model,
             @NotNull TomlValue value
     ) {
+        TypeAdapter<E> adapter = this.adapters.get(model.type());
+        if (adapter != null) return adapter.toJava(value.asPrimitive());
         if (model.isArray()) return this.serializeArray(model.asArray(), value.asArray());
         if (model.isTable()) return this.serializeTable(model.asTable(), value.asTable());
-
-        TypeAdapter<E> adapter = this.adapters.getAssert(model.type());
-        return adapter.toJava(value.asPrimitive());
+        throw new IllegalArgumentException("No adapter for type " + model.type().getName());
     }
 
     private <E> @NotNull E serializeArray(
@@ -212,11 +212,12 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
         if (!parents.add(value))
             throw new IllegalArgumentException("Cannot deserialize recursive data (" + value + " refers to itself)");
 
+        TypeAdapter<E> adapter = this.adapters.get(model.type());
+        if (adapter != null) return adapter.toToml(value);
         if (model.isArray()) return this.deserializeArray(parents, model.asArray(), value);
         if (model.isTable()) return this.deserializeTable(parents, model.asTable(), value);
 
-        TypeAdapter<E> adapter = this.adapters.getAssert(model.type());
-        return adapter.toToml(value);
+        throw new IllegalArgumentException("No adapter for type " + model.type().getName());
     }
 
     private <E> @NotNull TomlArray deserializeArray(

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -1,6 +1,7 @@
 package io.github.wasabithumb.jtoml.serial.reflect;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapter;
 import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapters;
@@ -12,15 +13,98 @@ import io.github.wasabithumb.jtoml.util.ReferenceHolder;
 import io.github.wasabithumb.jtoml.value.TomlValue;
 import io.github.wasabithumb.jtoml.value.array.TomlArray;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
+import io.github.wasabithumb.recsup.RecordSupport;
+import org.intellij.lang.annotations.MagicConstant;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
-final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
+import java.lang.reflect.Modifier;
+
+/**
+ * Handles reflection-powered conversion of TOML tables
+ * to/from a given table-like Java type. Supports
+ * both records and POJOs marked with {@link TomlSerializable}.
+ * @see #fromToml(TomlTable)
+ * @see #toToml(Object)
+ */
+public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
+
+    static final int C_SERIALIZE   = 1;
+    static final int C_DESERIALIZE = 2;
+
+    private static void checkType(
+            @NotNull Class<?> type,
+            @MagicConstant(flags = { C_SERIALIZE, C_DESERIALIZE }) int capabilities
+    ) throws IllegalArgumentException {
+        if (RecordSupport.isRecord(type)) return;
+        if (TomlSerializable.class.isAssignableFrom(type)) {
+            if ((capabilities & C_SERIALIZE) == 0) return;
+            int mod = type.getModifiers();
+            if (Modifier.isInterface(mod) || Modifier.isAbstract(mod)) {
+                raiseTypeError(type, capabilities, "not directly instantiable");
+            }
+        } else {
+            raiseTypeError(type, capabilities, "does not implement TomlSerializable and is not a record");
+        }
+    }
+
+    @Contract("_, _, _ -> fail")
+    private static void raiseTypeError(
+            @NotNull Class<?> type,
+            @MagicConstant(flags = { C_SERIALIZE, C_DESERIALIZE }) int capabilities,
+            @NotNull String detail
+    ) {
+        String classifier = ((capabilities & C_SERIALIZE) == 0) ? "deserializer" : "serializer";
+        throw new IllegalArgumentException("Cannot create " + classifier + " for " + type.getName() +
+                " (" + detail + ")");
+    }
+
+    //
 
     private final TableTypeModel<T> model;
+    private final TypeAdapters adapters;
+    private final int capabilities;
 
-    ReflectTomlSerializer(@NotNull Class<T> clazz) {
-        this.model = TypeModel.of(new ParameterizedClass<>(clazz))
-                .asTable();
+    /**
+     * Create a new serializer for converting objects of the given
+     * type to/from a TOML table. The newly created serializer will
+     * use the {@link TypeAdapters#standard() standard set} of adapters.
+     * @param type The table-like type to convert to/from.
+     * @throws IllegalArgumentException The given type is not serializable.
+     * @see #ReflectTomlSerializer(Class, TypeAdapters)
+     */
+    public ReflectTomlSerializer(
+            @NotNull Class<T> type
+    ) throws IllegalArgumentException {
+        this(type, TypeAdapters.standard());
+    }
+
+    /**
+     * Create a new serializer for converting objects of the given
+     * type to/from a TOML table.
+     * @param type The table-like type to convert to/from.
+     * @param adapters Describes how leaves in the document tree may be converted to/from Java objects.
+     * @throws IllegalArgumentException The given type is not serializable.
+     * @see #ReflectTomlSerializer(Class)
+     */
+    public ReflectTomlSerializer(
+            @NotNull Class<T> type,
+            @NotNull TypeAdapters adapters
+    ) throws IllegalArgumentException {
+        this(type, adapters, C_SERIALIZE | C_DESERIALIZE);
+    }
+
+    ReflectTomlSerializer(
+            @NotNull Class<T> type,
+            @NotNull TypeAdapters adapters,
+            @MagicConstant(flags = { C_SERIALIZE, C_DESERIALIZE }) int capabilities
+    ) {
+        checkType(type, capabilities);
+        TableTypeModel<T> model = TableTypeModel.match(new ParameterizedClass<>(type));
+        assert model != null;
+        this.model = model;
+        this.adapters = adapters;
+        this.capabilities = capabilities;
     }
 
     //
@@ -32,6 +116,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
 
     @Override
     public @NotNull T fromToml(@NotNull TomlTable table) {
+        if ((this.capabilities & C_SERIALIZE) == 0) throw new UnsupportedOperationException();
         return this.serializeTable(
                 this.model,
                 table
@@ -40,6 +125,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
 
     @Override
     public @NotNull TomlTable toToml(@NotNull T data) {
+        if ((this.capabilities & C_DESERIALIZE) == 0) throw new UnsupportedOperationException();
         ReferenceHolder parents = new ReferenceHolder();
         parents.add(this);
         return this.deserializeTable(
@@ -68,7 +154,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
         if (model.isArray()) return this.serializeArray(model.asArray(), value.asArray());
         if (model.isTable()) return this.serializeTable(model.asTable(), value.asTable());
 
-        TypeAdapter<E> adapter = TypeAdapters.get(model.type());
+        TypeAdapter<E> adapter = this.adapters.getAssert(model.type());
         return adapter.toJava(value.asPrimitive());
     }
 
@@ -129,7 +215,7 @@ final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<T> {
         if (model.isArray()) return this.deserializeArray(parents, model.asArray(), value);
         if (model.isTable()) return this.deserializeTable(parents, model.asTable(), value);
 
-        TypeAdapter<E> adapter = TypeAdapters.get(model.type());
+        TypeAdapter<E> adapter = this.adapters.getAssert(model.type());
         return adapter.toToml(value);
     }
 

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializerService.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializerService.java
@@ -4,11 +4,14 @@ import io.github.wasabithumb.jtoml.JToml;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.serial.TomlSerializerService;
+import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapters;
 import io.github.wasabithumb.recsup.RecordSupport;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Modifier;
 
+@ApiStatus.Internal
 public final class ReflectTomlSerializerService extends TomlSerializerService {
 
     @Override
@@ -30,27 +33,20 @@ public final class ReflectTomlSerializerService extends TomlSerializerService {
 
     @Override
     public @NotNull <T> TomlSerializer<?, T> getSerializer(@NotNull JToml instance, @NotNull Class<T> outType) {
-        if (!RecordSupport.isRecord(outType)) {
-            int mod = outType.getModifiers();
-            if (!TomlSerializable.class.isAssignableFrom(outType)) {
-                throw new IllegalArgumentException("Cannot create serializer for " + outType.getName() +
-                        " (does not implement TomlSerializable)");
-            }
-            if (Modifier.isInterface(mod) || Modifier.isAbstract(mod)) {
-                throw new IllegalArgumentException("Cannot create serializer for " + outType.getName() +
-                        " (not directly instantiable)");
-            }
-        }
-        return new ReflectTomlSerializer<>(outType);
+        return new ReflectTomlSerializer<>(
+                outType,
+                TypeAdapters.standard(),
+                ReflectTomlSerializer.C_SERIALIZE
+        );
     }
 
     @Override
     public @NotNull <T> TomlSerializer<T, ?> getDeserializer(@NotNull JToml instance, @NotNull Class<T> inType) {
-        if (!RecordSupport.isRecord(inType) && !TomlSerializable.class.isAssignableFrom(inType)) {
-            throw new IllegalArgumentException("Cannot create deserializer for " + inType.getName() +
-                    " (does not implement TomlSerializable)");
-        }
-        return new ReflectTomlSerializer<>(inType);
+        return new ReflectTomlSerializer<>(
+                inType,
+                TypeAdapters.standard(),
+                ReflectTomlSerializer.C_DESERIALIZE
+        );
     }
 
 }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapter.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapter.java
@@ -1,30 +1,190 @@
 package io.github.wasabithumb.jtoml.serial.reflect.adapter;
 
+import io.github.wasabithumb.jtoml.value.TomlValue;
 import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.function.Function;
 
-@ApiStatus.Internal
+/**
+ * Handles conversion of a single Java type to/from
+ * a TOML document leaf.
+ * @see #of(Class, Function, Function)
+ * @see #BOOL
+ * @see #BYTE
+ * @see #SHORT
+ * @see #INT
+ * @see #LONG
+ * @see #FLOAT
+ * @see #DOUBLE
+ * @see #CHAR
+ * @see #STRING
+ * @see #OFFSET_DATE_TIME
+ * @see #LOCAL_DATE_TIME
+ * @see #LOCAL_DATE
+ * @see #LOCAL_TIME
+ */
 public interface TypeAdapter<T> {
 
+    /**
+     * Helper function to create a new {@link TypeAdapter}.
+     * @param typeClass The Java type to adapt to/from a TOML value.
+     * @param toJava Function invoked to convert a TOML value to an instance of the given type.
+     * @param toToml Function invoked to convert an instance of the given type to a TOML value.
+     */
     @Contract("_, _, _ -> new")
-    static <O> @NotNull TypeAdapter<O> create(
+    static <O> @NotNull TypeAdapter<O> of(
             @NotNull Class<O> typeClass,
-            @NotNull Function<TomlPrimitive, O> toJava,
-            @NotNull Function<O, TomlPrimitive> toToml
+            @NotNull Function<TomlValue, O> toJava,
+            @NotNull Function<O, TomlValue> toToml
     ) {
-        return new BasicTypeAdapter<>(typeClass, toJava, toToml);
+        return new TypeAdapterImpl<>(typeClass, toJava, toToml);
     }
 
     //
 
+    /**
+     * Adapts TOML booleans to/from Java {@code boolean}/{@link Boolean} fields.
+     */
+    TypeAdapter<Boolean> BOOL = of(
+            Boolean.TYPE,
+            (TomlValue tv) -> tv.asPrimitive().asBoolean(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML integers to/from Java {@code byte}/{@link Byte} fields.
+     */
+    TypeAdapter<Byte> BYTE = of(
+            Byte.TYPE,
+            (TomlValue tv) -> (byte) tv.asPrimitive().asInteger(),
+            (Byte b) -> TomlPrimitive.of(b.intValue())
+    );
+
+    /**
+     * Adapts TOML integers to/from Java {@code short}/{@link Short} fields.
+     */
+    TypeAdapter<Short> SHORT = of(
+            Short.TYPE,
+            (TomlValue tv) -> (short) tv.asPrimitive().asInteger(),
+            (Short s) -> TomlPrimitive.of(s.intValue())
+    );
+
+    /**
+     * Adapts TOML integers to/from Java {@code int}/{@link Integer} fields.
+     */
+    TypeAdapter<Integer> INT = of(
+            Integer.TYPE,
+            (TomlValue tv) -> tv.asPrimitive().asInteger(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML integers to/from Java {@code long}/{@link Long} fields.
+     */
+    TypeAdapter<Long> LONG = of(
+            Long.TYPE,
+            (TomlValue tv) -> tv.asPrimitive().asLong(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML floats to/from Java {@code float}/{@link Float} fields.
+     */
+    TypeAdapter<Float> FLOAT = of(
+            Float.TYPE,
+            (TomlValue tv) -> tv.asPrimitive().asFloat(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML floats to/from Java {@code double}/{@link Double} fields.
+     */
+    TypeAdapter<Double> DOUBLE = of(
+            Double.TYPE,
+            (TomlValue tv) -> tv.asPrimitive().asDouble(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML strings to/from Java {@code char}/{@link Character} fields.
+     * Asserts that a TOML string is exactly 1 {@code char} (UTF-16 codepoint) in length.
+     */
+    TypeAdapter<Character> CHAR = of(
+            Character.TYPE,
+            (TomlValue tv) -> {
+                TomlPrimitive tp = tv.asPrimitive();
+                if (tp.isInteger()) {
+                    return (char) tp.asInteger();
+                } else {
+                    String s = tp.asString();
+                    if (s.length() != 1) throw new IllegalStateException("Cannot convert multi-char string to char");
+                    return s.charAt(0);
+                }
+            },
+            (Character c) -> TomlPrimitive.of(Character.toString(c))
+    );
+
+    /**
+     * Adapts TOML strings to/from Java {@link String} fields.
+     */
+    TypeAdapter<String> STRING = of(
+            String.class,
+            (TomlValue tv) -> tv.asPrimitive().asString(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML offset date-times to/from Java {@link OffsetDateTime} fields.
+     */
+    TypeAdapter<OffsetDateTime> OFFSET_DATE_TIME = of(
+            OffsetDateTime.class,
+            (TomlValue tv) -> tv.asPrimitive().asOffsetDateTime(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML local date-times to/from Java {@link LocalDateTime} fields.
+     */
+    TypeAdapter<LocalDateTime> LOCAL_DATE_TIME = of(
+            LocalDateTime.class,
+            (TomlValue tv) -> tv.asPrimitive().asLocalDateTime(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML local dates to/from Java {@link LocalDate} fields.
+     */
+    TypeAdapter<LocalDate> LOCAL_DATE = of(
+            LocalDate.class,
+            (TomlValue tv) -> tv.asPrimitive().asLocalDate(),
+            TomlPrimitive::of
+    );
+
+    /**
+     * Adapts TOML local times to/from Java {@link LocalTime} fields.
+     */
+    TypeAdapter<LocalTime> LOCAL_TIME = of(
+            LocalTime.class,
+            (TomlValue tv) -> tv.asPrimitive().asLocalTime(),
+            TomlPrimitive::of
+    );
+
+    //
+
+    @ApiStatus.Internal
     @NotNull Class<T> typeClass();
 
-    @NotNull T toJava(@NotNull TomlPrimitive toml);
+    @ApiStatus.Internal
+    @NotNull T toJava(@NotNull TomlValue toml);
 
-    @NotNull TomlPrimitive toToml(@NotNull T java);
+    @ApiStatus.Internal
+    @NotNull TomlValue toToml(@NotNull T java);
 
 }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapterImpl.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapterImpl.java
@@ -1,20 +1,22 @@
 package io.github.wasabithumb.jtoml.serial.reflect.adapter;
 
-import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
+import io.github.wasabithumb.jtoml.value.TomlValue;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
-final class BasicTypeAdapter<T> implements TypeAdapter<T> {
+@ApiStatus.Internal
+final class TypeAdapterImpl<T> implements TypeAdapter<T> {
 
     private final Class<T> typeClass;
-    private final Function<TomlPrimitive, T> toJava;
-    private final Function<T, TomlPrimitive> toToml;
+    private final Function<TomlValue, T> toJava;
+    private final Function<T, TomlValue> toToml;
 
-    BasicTypeAdapter(
+    TypeAdapterImpl(
             @NotNull Class<T> typeClass,
-            @NotNull Function<TomlPrimitive, T> toJava,
-            @NotNull Function<T, TomlPrimitive> toToml
+            @NotNull Function<TomlValue, T> toJava,
+            @NotNull Function<T, TomlValue> toToml
     ) {
         this.typeClass = typeClass;
         this.toJava = toJava;
@@ -29,12 +31,12 @@ final class BasicTypeAdapter<T> implements TypeAdapter<T> {
     }
 
     @Override
-    public @NotNull T toJava(@NotNull TomlPrimitive toml) {
+    public @NotNull T toJava(@NotNull TomlValue toml) {
         return this.toJava.apply(toml);
     }
 
     @Override
-    public @NotNull TomlPrimitive toToml(@NotNull T java) {
+    public @NotNull TomlValue toToml(@NotNull T java) {
         return this.toToml.apply(java);
     }
 

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapters.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapters.java
@@ -44,13 +44,6 @@ public interface TypeAdapters extends Collection<TypeAdapter<?>> {
     @ApiStatus.Internal
     <T> @Nullable TypeAdapter<T> get(@NotNull Class<T> type);
 
-    @ApiStatus.Internal
-    default <T> @NotNull TypeAdapter<T> getAssert(@NotNull Class<T> type) throws IllegalArgumentException {
-        TypeAdapter<T> adapter = this.get(type);
-        if (adapter == null) throw new IllegalArgumentException("No adapter for type " + type.getName());
-        return adapter;
-    }
-
     //
 
     /**

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapters.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdapters.java
@@ -1,159 +1,111 @@
 package io.github.wasabithumb.jtoml.serial.reflect.adapter;
 
-import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collection;
 
-import static io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapter.*;
+/**
+ * An immutable collection of {@link TypeAdapter}s for use
+ * in {@link io.github.wasabithumb.jtoml.serial.reflect.ReflectTomlSerializer reflect serialization}.
+ * @see #builder()
+ * @see #standard()
+ */
+@ApiStatus.NonExtendable
+public interface TypeAdapters extends Collection<TypeAdapter<?>> {
 
-@ApiStatus.Internal
-public final class TypeAdapters {
-
-    private static final Map<Class<?>, TypeAdapter<?>> MAP;
-    static {
-        Map<Class<?>, TypeAdapter<?>> map = new HashMap<>();
-        TypeAdapter<?> tmp;
-
-        // Boolean
-        tmp = create(
-                Boolean.class,
-                TomlPrimitive::asBoolean,
-                TomlPrimitive::of
-        );
-        map.put(Boolean.class, tmp);
-        map.put(Boolean.TYPE, tmp);
-
-        // Byte
-        tmp = create(
-                Byte.class,
-                (TomlPrimitive v) -> (byte) v.asInteger(),
-                (Byte b) -> TomlPrimitive.of(b.intValue())
-        );
-        map.put(Byte.class, tmp);
-        map.put(Byte.TYPE, tmp);
-
-        // Short
-        tmp = create(
-                Short.class,
-                (TomlPrimitive v) -> (short) v.asInteger(),
-                (Short s) -> TomlPrimitive.of(s.intValue())
-        );
-        map.put(Short.class, tmp);
-        map.put(Short.TYPE, tmp);
-
-        // Integer
-        tmp = create(
-                Integer.class,
-                TomlPrimitive::asInteger,
-                TomlPrimitive::of
-        );
-        map.put(Integer.class, tmp);
-        map.put(Integer.TYPE, tmp);
-
-        // Long
-        tmp = create(
-                Long.class,
-                TomlPrimitive::asLong,
-                TomlPrimitive::of
-        );
-        map.put(Long.class, tmp);
-        map.put(Long.TYPE, tmp);
-
-        // Float
-        tmp = create(
-                Float.class,
-                TomlPrimitive::asFloat,
-                TomlPrimitive::of
-        );
-        map.put(Float.class, tmp);
-        map.put(Float.TYPE, tmp);
-
-        // Double
-        tmp = create(
-                Double.class,
-                TomlPrimitive::asDouble,
-                TomlPrimitive::of
-        );
-        map.put(Double.class, tmp);
-        map.put(Double.TYPE, tmp);
-
-        // Character
-        tmp = create(
-                Character.class,
-                (TomlPrimitive tp) -> {
-                    if (tp.isInteger()) {
-                        return (char) tp.asInteger();
-                    } else {
-                        String s = tp.asString();
-                        if (s.length() != 1) throw new IllegalStateException("Cannot convert multi-char string to char");
-                        return s.charAt(0);
-                    }
-                },
-                (Character c) -> TomlPrimitive.of(Character.toString(c))
-        );
-        map.put(Character.class, tmp);
-        map.put(Character.TYPE, tmp);
-
-        // String
-        tmp = create(
-                String.class,
-                TomlPrimitive::asString,
-                TomlPrimitive::of
-        );
-        map.put(String.class, tmp);
-
-        // Offset Date-Time
-        tmp = create(
-                OffsetDateTime.class,
-                TomlPrimitive::asOffsetDateTime,
-                TomlPrimitive::of
-        );
-        map.put(OffsetDateTime.class, tmp);
-
-        // Local Date-Time
-        tmp = create(
-                LocalDateTime.class,
-                TomlPrimitive::asLocalDateTime,
-                TomlPrimitive::of
-        );
-        map.put(LocalDateTime.class, tmp);
-
-        // Local Date
-        tmp = create(
-                LocalDate.class,
-                TomlPrimitive::asLocalDate,
-                TomlPrimitive::of
-        );
-        map.put(LocalDate.class, tmp);
-
-        // Local Time
-        tmp = create(
-                LocalTime.class,
-                TomlPrimitive::asLocalTime,
-                TomlPrimitive::of
-        );
-        map.put(LocalTime.class, tmp);
-
-        MAP = map;
+    /**
+     * Provides a new builder for creating
+     * custom {@link TypeAdapter} collections.
+     * This builder is initially empty and does not
+     * contain any of the
+     * {@link #standard() standard adapters}.
+     */
+    @Contract("-> new")
+    static @NotNull Builder builder() {
+        return new TypeAdaptersImpl.Builder();
     }
 
-    @SuppressWarnings("unchecked")
-    public static <T> @NotNull TypeAdapter<T> get(@NotNull Class<T> type) {
-        TypeAdapter<?> ret = MAP.get(type);
-        if (ret == null)
-            throw new IllegalArgumentException("No registered adapter for type "  + type.getName());
-        return (TypeAdapter<T>) ret;
+    /**
+     * Provides a {@link TypeAdapters} instance
+     * containing every constant defined
+     * in {@link TypeAdapter}. This is the default
+     * set of adapters used by the reflect serializer.
+     */
+    @Contract(pure = true)
+    static @NotNull TypeAdapters standard() {
+        return TypeAdaptersImpl.STANDARD;
     }
 
     //
 
-    private TypeAdapters() { }
+    @ApiStatus.Internal
+    <T> @Nullable TypeAdapter<T> get(@NotNull Class<T> type);
+
+    @ApiStatus.Internal
+    default <T> @NotNull TypeAdapter<T> getAssert(@NotNull Class<T> type) throws IllegalArgumentException {
+        TypeAdapter<T> adapter = this.get(type);
+        if (adapter == null) throw new IllegalArgumentException("No adapter for type " + type.getName());
+        return adapter;
+    }
+
+    //
+
+    /**
+     * Handles creation of custom {@link TypeAdapters}
+     * collections.
+     * @see #clear()
+     * @see #add(TypeAdapter)
+     * @see #add(Collection)
+     * @see #build()
+     */
+    @ApiStatus.NonExtendable
+    interface Builder {
+
+        /**
+         * Clears the builder,
+         * removing all adapters previously
+         * added to it.
+         */
+        @Contract("-> this")
+        @NotNull Builder clear();
+
+        /**
+         * Adds a new type adapter.
+         * If an adapter with the same {@link TypeAdapter#typeClass() type class}
+         * was already added, that adapter is replaced.
+         * If the adapter's type class is
+         * primitive, it is additionally added as if it were
+         * the boxed variant.
+         */
+        @Contract("_ -> this")
+        @NotNull Builder add(@NotNull TypeAdapter<?> adapter);
+
+        /**
+         * Adds each type adapter contained in the
+         * given collection to this builder.
+         * Can be used to inherit the standard adapters
+         * via {@code add(TypeAdapters.standard())}.
+         * @see #add(TypeAdapter)
+         */
+        @Contract("_ -> this")
+        default @NotNull Builder add(@NotNull Collection<TypeAdapter<?>> adapters) {
+            for (TypeAdapter<?> adapter : adapters) {
+                this.add(adapter);
+            }
+            return this;
+        }
+
+        /**
+         * Provides a new {@link TypeAdapters} instance
+         * containing all adapters added to this builder.
+         * The builder may not be used after this point.
+         */
+        @Contract("-> new")
+        @NotNull TypeAdapters build();
+
+    }
 
 }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdaptersImpl.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/adapter/TypeAdaptersImpl.java
@@ -1,0 +1,134 @@
+package io.github.wasabithumb.jtoml.serial.reflect.adapter;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+@ApiStatus.Internal
+final class TypeAdaptersImpl extends AbstractCollection<TypeAdapter<?>> implements TypeAdapters {
+
+    static final TypeAdaptersImpl STANDARD;
+    static {
+        Builder builder = new Builder();
+        TypeAdapter<?> next;
+        for (Field field : TypeAdapter.class.getDeclaredFields()) {
+            int mod = field.getModifiers();
+            if (!Modifier.isStatic(mod)) continue;
+            if (!Modifier.isPublic(mod)) continue;
+            if (!TypeAdapter.class.isAssignableFrom(field.getType())) continue;
+            try {
+                next = (TypeAdapter<?>) field.get(null);
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to read value of constant " + field.getName());
+            }
+            builder.add(next);
+        }
+        STANDARD = builder.build();
+    }
+
+    //
+
+    private final Map<Class<?>, TypeAdapter<?>> map;
+
+    private TypeAdaptersImpl(@NotNull Map<Class<?>, TypeAdapter<?>> map) {
+        this.map = Collections.unmodifiableMap(map);
+    }
+
+    //
+
+    @Override
+    public int size() {
+        return this.map.size();
+    }
+
+    @Override
+    public @NotNull Iterator<TypeAdapter<?>> iterator() {
+        return this.map.values().iterator();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @Nullable <T> TypeAdapter<T> get(@NotNull Class<T> type) {
+        TypeAdapter<?> raw = this.map.get(type);
+        if (raw == null) return null;
+        return (TypeAdapter<T>) raw;
+    }
+
+    //
+
+    static final class Builder implements TypeAdapters.Builder {
+
+        private final Map<Class<?>, TypeAdapter<?>> map;
+        private volatile boolean open;
+
+        Builder() {
+            this.map = new HashMap<>();
+            this.open = true;
+        }
+
+        //
+
+        @Override
+        public @NotNull Builder clear() {
+            this.checkOpen();
+            this.map.clear();
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder add(@NotNull TypeAdapter<?> adapter) {
+            this.checkOpen();
+
+            Class<?> type = adapter.typeClass();
+            this.map.put(type, adapter);
+
+            type = getBoxedCounterpart(type);
+            if (type != null) this.map.put(type, adapter);
+
+            return this;
+        }
+
+        @Override
+        public @NotNull TypeAdaptersImpl build() {
+            this.checkOpen();
+            this.open = false;
+            return new TypeAdaptersImpl(this.map);
+        }
+
+        //
+
+        private void checkOpen() throws IllegalStateException {
+            if (this.open) return;
+            throw new IllegalStateException("Cannot use builder after #build()");
+        }
+
+        private static @Nullable Class<?> getBoxedCounterpart(@NotNull Class<?> type) {
+            if (!type.isPrimitive()) return null;
+            String name = type.getName();
+            switch (name.charAt(0)) {
+                case 'b':
+                    return name.charAt(1) == 'y' ? Byte.class : Boolean.class;
+                case 'i':
+                    return Integer.class;
+                case 'f':
+                    return Float.class;
+                case 'd':
+                    return Double.class;
+                case 'c':
+                    return Character.class;
+                case 'l':
+                    return Long.class;
+                case 's':
+                    return Short.class;
+                default:
+                    return Void.class;
+            }
+        }
+
+    }
+
+}

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
@@ -43,13 +43,12 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
         Key annotation = f.getAnnotation(Key.class);
         if (annotation != null) name = annotation.value();
         TomlKey key = TomlKey.literal(name);
-        Field existing = map.get(key);
+        Field existing = map.put(key, f);
         if (existing != null) {
             throw new IllegalStateException("Serializable field (" + f.getName() + ") with key " + key +
                     " shadows field (" + existing.getName() + ") with same key declared in class " +
                     existing.getDeclaringClass().getName());
         }
-        map.put(key, f);
     }
 
     //

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/NamedTriplet.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/NamedTriplet.java
@@ -1,4 +1,7 @@
 package io.github.wasabithumb.jtoml.dummy;
 
-public class NamedTriplet {
-}
+public record NamedTriplet (
+        Named first,
+        Named second,
+        Named third
+) { }

--- a/src/test/java/io/github/wasabithumb/jtoml/dummy/NamedTriplet.java
+++ b/src/test/java/io/github/wasabithumb/jtoml/dummy/NamedTriplet.java
@@ -1,0 +1,4 @@
+package io.github.wasabithumb.jtoml.dummy;
+
+public class NamedTriplet {
+}


### PR DESCRIPTION
Serializers now have a public, canonical and documented method of acquisition and use. This can be used to sidestep the service loading mechanism (#14) and/or configure serializer-specific options. In the case of the reflect serializer, type adapters have been slightly reworked to allow definition of custom adapters through the API. As a consequence, the adapter system is no longer marked as internal. Due to its previous designation as an internal, the changes made to it should not be considered breaking.