### PR TITLE
Implement key convention system

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/JToml.java
@@ -67,6 +67,13 @@ public interface JToml {
     @NotNull String version();
 
     /**
+     * Reports the configured options of this
+     * JToml instance. This is immutable, you cannot
+     * modify the options of a created instance.
+     */
+    @NotNull JTomlOptions options();
+
+    /**
      * Reads a TOML table from a string
      * @param toml A string containing a TOML document
      * @throws TomlException String is not valid TOML

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/TomlKey.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/TomlKey.java
@@ -81,6 +81,26 @@ public interface TomlKey extends Collection<String>, Comparable<TomlKey> {
         return new ArrayTomlKey(cpy);
     }
 
+    /**
+     * Wraps a pre-parsed TOML key (by parts) into a {@link TomlKey} object.
+     * No parsing is performed.
+     * @see #parse(CharSequence)
+     */
+    @ApiStatus.Experimental
+    @Contract("_ -> new")
+    static @NotNull TomlKey literal(@NotNull Collection<? extends CharSequence> parts) {
+        final int len = parts.size();
+        String[] cpy = new String[len];
+
+        Iterator<? extends CharSequence> iter = parts.iterator();
+        for (int i = 0; i < len; i++) {
+            if (!iter.hasNext()) throw new ConcurrentModificationException();
+            cpy[i] = iter.next().toString();
+        }
+
+        return new ArrayTomlKey(cpy);
+    }
+
     //
 
     /**

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConvention.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConvention.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.wasabithumb.jtoml.key.convention;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConvention.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConvention.java
@@ -1,0 +1,27 @@
+package io.github.wasabithumb.jtoml.key.convention;
+
+import io.github.wasabithumb.jtoml.key.TomlKey;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Determines how a given identifier may be
+ * converted to a {@link TomlKey}. This is currently
+ * used by the reflect serializer to map fields and
+ * record components to their corresponding keys in
+ * absence of an explicit mapping. Owing to the general
+ * use cases of this interface, the
+ * {@link StandardKeyConvention standard conventions}
+ * appropriately expect input to be strict ASCII in
+ * {@code camelCase}.
+ * @see StandardKeyConvention
+ */
+@FunctionalInterface
+public interface KeyConvention {
+
+    /**
+     * Adapts the given identifier into a {@link TomlKey}
+     * based on the convention.
+     */
+    @NotNull TomlKey toToml(@NotNull String key);
+    
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConventionOps.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConventionOps.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.wasabithumb.jtoml.key.convention;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConventionOps.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/KeyConventionOps.java
@@ -1,0 +1,84 @@
+package io.github.wasabithumb.jtoml.key.convention;
+
+import io.github.wasabithumb.jtoml.key.TomlKey;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+@ApiStatus.Internal
+final class KeyConventionOps {
+
+    static @NotNull TomlKey identity(@NotNull String string) {
+        return TomlKey.literal(string);
+    }
+
+    static @NotNull TomlKey lower(@NotNull String string) {
+        return TomlKey.literal(string.toLowerCase(Locale.ROOT));
+    }
+
+    static @NotNull TomlKey camelToKebab(@NotNull String string) {
+        return camelToDelimited(string, '-');
+    }
+
+    static @NotNull TomlKey camelToSnake(@NotNull String string) {
+        return camelToDelimited(string, '_');
+    }
+
+    static @NotNull TomlKey camelToSplit(@NotNull String string) {
+        List<String> list = new LinkedList<>();
+        camelParse(string, list::add, null);
+        return TomlKey.literal(list);
+    }
+
+    private static @NotNull TomlKey camelToDelimited(@NotNull String string, char delim) {
+        StringBuilder ret = new StringBuilder(string.length());
+        camelParse(string, ret::append, () -> ret.append(delim));
+        return TomlKey.literal(ret.toString());
+    }
+
+    private static void camelParse(
+            @NotNull String string,
+            @NotNull Consumer<String> acceptPart,
+            @Nullable Runnable runBetween
+    ) {
+        final int len = string.length();
+        int f = (runBetween == null) ? 2 : 0;
+        char[] buf = new char[len];
+        int head = 0;
+        char c;
+
+        for (int i = 0; i < len; ) {
+            c = string.charAt(i++);
+            if ('A' > c || c > 'Z') {
+                buf[head++] = c;
+                continue;
+            }
+            if (head != 0) {
+                if (f == 1) runBetween.run();
+                acceptPart.accept(new String(buf, 0, head));
+                f |= 1;
+                head = 0;
+            }
+            buf[head++] = (char) (c + 0x20);
+            while (i < len && 'A' <= (c = string.charAt(i)) && c <= 'Z') {
+                buf[head++] = (char) (c + 0x20);
+                i++;
+            }
+        }
+
+        if (head != 0) {
+            if (f == 1) runBetween.run();
+            acceptPart.accept(new String(buf, 0, head));
+        }
+    }
+
+    //
+
+    private KeyConventionOps() { }
+
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/StandardKeyConvention.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/StandardKeyConvention.java
@@ -1,0 +1,95 @@
+package io.github.wasabithumb.jtoml.key.convention;
+
+import io.github.wasabithumb.jtoml.key.TomlKey;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+/**
+ * Enumeration of standard {@link KeyConvention} implementations.
+ * As an enum, these may be used in the {@code @Convention} annotation.
+ *
+ * <table>
+ *     <caption>Comparison</caption>
+ *     <tr>
+ *         <th>{@link #LITERAL}</th>
+ *         <th>{@link #LOWER}</th>
+ *         <th>{@link #KEBAB}</th>
+ *         <th>{@link #SNAKE}</th>
+ *         <th>{@link #SPLIT}</th>
+ *     </tr>
+ *     <tr>
+ *         <td><pre>{@code helloWorld}</pre></td>
+ *         <td><pre>{@code helloworld}</pre></td>
+ *         <td><pre>{@code hello-world}</pre></td>
+ *         <td><pre>{@code hello_world}</pre></td>
+ *         <td><pre>{@code hello.world}</pre></td>
+ *     </tr>
+ * </table>
+ *
+ * @see #LITERAL
+ * @see #LOWER
+ * @see #KEBAB
+ * @see #SNAKE
+ * @see #SPLIT
+ */
+public enum StandardKeyConvention implements KeyConvention {
+
+    /**
+     * Produces a {@link TomlKey} consisting
+     * of a single part equal to the given identifier
+     */
+    LITERAL(KeyConventionOps::identity),
+
+    /**
+     * Produces a {@link TomlKey} consisting
+     * of a single part equal to the given identifier in lowercase
+     */
+    LOWER(KeyConventionOps::lower),
+
+    /**
+     * Produces a {@link TomlKey} consisting
+     * of a single part based on the given identifier.
+     * To create this part, the identifier is lowercased
+     * and the character {@code -} is placed before runs
+     * of characters which were uppercase.
+     */
+    KEBAB(KeyConventionOps::camelToKebab),
+
+    /**
+     * Produces a {@link TomlKey} consisting
+     * of a single part based on the given identifier.
+     * To create this part, the identifier is lowercased
+     * and the character {@code _} is placed before runs
+     * of characters which were uppercase.
+     */
+    SNAKE(KeyConventionOps::camelToSnake),
+
+    /**
+     * Produces a {@link TomlKey} consisting
+     * of one or more parts based on the given identifier.
+     * The identifier is split by the start of any run
+     * of uppercase characters, between which a part is
+     * generated from the lowercase value of that text.
+     * @apiNote Behavior is not well tested at this time.
+     */
+    @ApiStatus.Experimental
+    SPLIT(KeyConventionOps::camelToSplit);
+
+    //
+
+    private final Function<String, TomlKey> operator;
+
+    StandardKeyConvention(Function<String, TomlKey> operator) {
+        this.operator = operator;
+    }
+
+    //
+
+    @Override
+    public @NotNull TomlKey toToml(@NotNull String key) {
+        return this.operator.apply(key);
+    }
+    
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/StandardKeyConvention.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/key/convention/StandardKeyConvention.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.wasabithumb.jtoml.key.convention;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/option/JTomlOption.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/option/JTomlOption.java
@@ -16,6 +16,8 @@
 
 package io.github.wasabithumb.jtoml.option;
 
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
+import io.github.wasabithumb.jtoml.key.convention.StandardKeyConvention;
 import io.github.wasabithumb.jtoml.option.prop.*;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
@@ -36,17 +38,29 @@ public interface JTomlOption<T> {
     /**
      * Indentation to apply when writing
      */
-    JTomlOption<IndentationPolicy> INDENTATION = of("INDENTATION", IndentationPolicy.class, IndentationPolicy.STANDARD);
+    JTomlOption<IndentationPolicy> INDENTATION = of(
+            "INDENTATION",
+            IndentationPolicy.class,
+            IndentationPolicy.STANDARD
+    );
 
     /**
      * Spacing to apply when writing
      */
-    JTomlOption<SpacingPolicy> SPACING = of("SPACING", SpacingPolicy.class, SpacingPolicy.STANDARD);
+    JTomlOption<SpacingPolicy> SPACING = of(
+            "SPACING",
+            SpacingPolicy.class,
+            SpacingPolicy.STANDARD
+    );
 
     /**
      * Padding to apply when writing
      */
-    JTomlOption<PaddingPolicy> PADDING = of("PADDING", PaddingPolicy.class, PaddingPolicy.STANDARD);
+    JTomlOption<PaddingPolicy> PADDING = of(
+            "PADDING",
+            PaddingPolicy.class,
+            PaddingPolicy.STANDARD
+    );
 
     /**
      * Zone offset to use when reading a <a href="https://toml.io/en/v1.1.0#local-date-time">Local Date-Time</a>
@@ -54,7 +68,11 @@ public interface JTomlOption<T> {
      * and when writing a {@link java.time.LocalDateTime LocalDateTime} as an
      * <a href="https://toml.io/en/v1.1.0#offset-date-time">Offset Date-Time</a>
      */
-    JTomlOption<ZoneOffset> TIME_ZONE = of("TIME_ZONE", ZoneOffset.class, ZoneOffset.UTC);
+    JTomlOption<ZoneOffset> TIME_ZONE = of(
+            "TIME_ZONE",
+            ZoneOffset.class,
+            ZoneOffset.UTC
+    );
 
     /**
      * Determines if a BOM should be read.
@@ -67,12 +85,20 @@ public interface JTomlOption<T> {
      * </pre>
      * Hence, the default is {@link OrderMarkPolicy#NEVER NEVER}.
      */
-    JTomlOption<OrderMarkPolicy> READ_BOM = of("READ_BOM", OrderMarkPolicy.class, OrderMarkPolicy.NEVER);
+    JTomlOption<OrderMarkPolicy> READ_BOM = of(
+            "READ_BOM",
+            OrderMarkPolicy.class,
+            OrderMarkPolicy.NEVER
+    );
 
     /**
      * Determines if a BOM should be written
      */
-    JTomlOption<OrderMarkPolicy> WRITE_BOM = of("WRITE_BOM", OrderMarkPolicy.class, OrderMarkPolicy.IF_PRESENT);
+    JTomlOption<OrderMarkPolicy> WRITE_BOM = of(
+            "WRITE_BOM",
+            OrderMarkPolicy.class,
+            OrderMarkPolicy.IF_PRESENT
+    );
 
     /**
      * The line separator to use when writing and normalizing,
@@ -80,47 +106,71 @@ public interface JTomlOption<T> {
      * Default is determined by {@link System#lineSeparator()}.
      * Both line endings can always be read, irrespective of the value of this option.
      */
-    JTomlOption<LineSeparator> LINE_SEPARATOR = of("LINE_SEPARATOR", LineSeparator.class, LineSeparator.SYSTEM);
+    JTomlOption<LineSeparator> LINE_SEPARATOR = of(
+            "LINE_SEPARATOR",
+            LineSeparator.class,
+            LineSeparator.SYSTEM
+    );
 
     /**
      * If true, {@link io.github.wasabithumb.jtoml.except.parse.TomlExtensionException static extension} is
      * prohibited. This is required for the parser to be fully TOML-compliant.
      */
-    Bool EXTENSION_GUARD = of("EXTENSION_GUARD", true);
+    Bool EXTENSION_GUARD = of(
+            "EXTENSION_GUARD",
+            true
+    );
 
     /**
      * If true, table headers will be written even if they do not
      * contain any key-values or comments.
      */
     @ApiStatus.AvailableSince("0.2.3")
-    Bool WRITE_EMPTY_TABLES = of("WRITE_EMPTY_TABLES", false);
+    Bool WRITE_EMPTY_TABLES = of(
+            "WRITE_EMPTY_TABLES",
+            false
+    );
 
     /**
      * If true, comments will be stored in the resulting document
      * (rather than ignored) when reading
      */
     @ApiStatus.AvailableSince("0.6.0")
-    Bool READ_COMMENTS = of("READ_COMMENTS", true);
+    Bool READ_COMMENTS = of(
+            "READ_COMMENTS",
+            true
+    );
 
     /**
      * If true, comments defined on values will be written.
      */
     @ApiStatus.AvailableSince("0.6.0")
-    Bool WRITE_COMMENTS = of("WRITE_COMMENTS", true);
+    Bool WRITE_COMMENTS = of(
+            "WRITE_COMMENTS",
+            true
+    );
 
     /**
      * Determines how non-table arrays should be written;
      * specifically when elements should receive a newline
      */
     @ApiStatus.AvailableSince("0.6.0")
-    JTomlOption<ArrayStrategy> ARRAY_STRATEGY = of("ARRAY_STRATEGY", ArrayStrategy.class, ArrayStrategy.DYNAMIC);
+    JTomlOption<ArrayStrategy> ARRAY_STRATEGY = of(
+            "ARRAY_STRATEGY",
+            ArrayStrategy.class,
+            ArrayStrategy.DYNAMIC
+    );
 
     /**
      * Determines how keys are sorted within a table
      * when writing.
      */
     @ApiStatus.AvailableSince("1.3.0")
-    JTomlOption<SortMethod> SORTING = of("SORTING", SortMethod.class, SortMethod.STRATIFIED);
+    JTomlOption<SortMethod> SORTING = of(
+            "SORTING",
+            SortMethod.class,
+            SortMethod.STRATIFIED
+    );
 
     /**
      * Determines the version of the TOML spec
@@ -128,7 +178,26 @@ public interface JTomlOption<T> {
      * {@link SpecVersion#latest() the latest supported version}.
      */
     @ApiStatus.AvailableSince("1.4.0")
-    JTomlOption<SpecVersion> COMPLIANCE = of("COMPLIANCE", SpecVersion.class, SpecVersion.latest());
+    JTomlOption<SpecVersion> COMPLIANCE = of(
+            "COMPLIANCE",
+            SpecVersion.class,
+            SpecVersion.latest()
+    );
+
+    /**
+     * Determines the default {@link KeyConvention} to use
+     * during reflect serialization. This determines how
+     * a field/component declared on a serialized class/record should
+     * be mapped to a TOML key unless otherwise specified
+     * with the {@code @Key} or {@code @Convention} annotations
+     * at the type or member level. Defaults to
+     * {@link StandardKeyConvention#LITERAL LITERAL}.
+     */
+    JTomlOption<KeyConvention> DEFAULT_KEY_CONVENTION = of(
+            "DEFAULT_KEY_CONVENTION",
+            KeyConvention.class,
+            StandardKeyConvention.LITERAL
+    );
 
     //
 

--- a/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
+++ b/kotlin/src/main/kotlin/io/github/wasabithumb/jtoml/KToml.kt
@@ -68,6 +68,10 @@ object KToml : JToml {
         return this.instance.version()
     }
 
+    override fun options(): JTomlOptions {
+        return this.instance.options()
+    }
+
     @Throws(TomlException::class)
     override fun readFromString(toml: String): TomlDocument {
         return this.instance.readFromString(toml)
@@ -119,6 +123,11 @@ object KToml : JToml {
 
 val JToml.version: String
     get() = this.version()
+
+// Options
+
+val JToml.options: JTomlOptions
+    get() = this.options()
 
 // Serialization
 

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Convention.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Convention.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.wasabithumb.jtoml.serial.reflect;
+
+import io.github.wasabithumb.jtoml.key.convention.StandardKeyConvention;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation for use in {@link io.github.wasabithumb.jtoml.serial.TomlSerializable reflect serialization}.
+ * Overrides the {@link io.github.wasabithumb.jtoml.key.convention.KeyConvention key convention} in use
+ * at the class/record or member level. Due to JVM restrictions, only the
+ * {@link StandardKeyConvention standard conventions} may be used with this annotation.
+ *
+ * @see Literal
+ * @see Lower
+ * @see Kebab
+ * @see Snake
+ * @see Split
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+public @interface Convention {
+    @NotNull StandardKeyConvention value();
+
+    //
+
+    /**
+     * Identical to {@code @Convention(KeyConvention.LITERAL)}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @interface Literal {
+        @SuppressWarnings("unused")
+        StandardKeyConvention VALUE = StandardKeyConvention.LITERAL;
+    }
+
+    /**
+     * Identical to {@code @Convention(KeyConvention.LOWER)}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @interface Lower {
+        @SuppressWarnings("unused")
+        StandardKeyConvention VALUE = StandardKeyConvention.LOWER;
+    }
+
+    /**
+     * Identical to {@code @Convention(KeyConvention.KEBAB)}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @interface Kebab {
+        @SuppressWarnings("unused")
+        StandardKeyConvention VALUE = StandardKeyConvention.KEBAB;
+    }
+
+    /**
+     * Identical to {@code @Convention(KeyConvention.SNAKE)}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @interface Snake {
+        @SuppressWarnings("unused")
+        StandardKeyConvention VALUE = StandardKeyConvention.SNAKE;
+    }
+
+    /**
+     * Identical to {@code @Convention(KeyConvention.SPLIT)}
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @ApiStatus.Experimental
+    @interface Split {
+        @SuppressWarnings("unused")
+        StandardKeyConvention VALUE = StandardKeyConvention.SPLIT;
+    }
+
+}

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -17,6 +17,8 @@
 package io.github.wasabithumb.jtoml.serial.reflect;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
+import io.github.wasabithumb.jtoml.key.convention.StandardKeyConvention;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapter;
@@ -36,6 +38,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Modifier;
+import java.util.Map;
 
 /**
  * Handles reflection-powered conversion of TOML tables
@@ -81,15 +84,17 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
 
     private final TableTypeModel<T> model;
     private final TypeAdapters adapters;
+    private final KeyConvention defaultConvention;
     private final int capabilities;
 
     /**
      * Create a new serializer for converting objects of the given
      * type to/from a TOML table. The newly created serializer will
-     * use the {@link TypeAdapters#standard() standard set} of adapters.
+     * use the {@link TypeAdapters#standard() standard set} of adapters
+     * and use {@link StandardKeyConvention#LITERAL LITERAL} as the
+     * default key convention.
      * @param type The table-like type to convert to/from.
      * @throws IllegalArgumentException The given type is not serializable.
-     * @see #ReflectTomlSerializer(Class, TypeAdapters)
      */
     public ReflectTomlSerializer(
             @NotNull Class<T> type
@@ -99,22 +104,54 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
 
     /**
      * Create a new serializer for converting objects of the given
-     * type to/from a TOML table.
+     * type to/from a TOML table. The newly created serializer will use
+     * {@link StandardKeyConvention#LITERAL LITERAL} as the default key convention.
      * @param type The table-like type to convert to/from.
      * @param adapters Describes how leaves in the document tree may be converted to/from Java objects.
      * @throws IllegalArgumentException The given type is not serializable.
-     * @see #ReflectTomlSerializer(Class)
      */
     public ReflectTomlSerializer(
             @NotNull Class<T> type,
             @NotNull TypeAdapters adapters
     ) throws IllegalArgumentException {
-        this(type, adapters, C_SERIALIZE | C_DESERIALIZE);
+        this(type, adapters, StandardKeyConvention.LITERAL);
+    }
+
+    /**
+     * Create a new serializer for converting objects of the given
+     * type to/from a TOML table. The newly created serializer will
+     * use the {@link TypeAdapters#standard() standard set} of adapters.
+     * @param type The table-like type to convert to/from.
+     * @param defaultConvention The default {@link KeyConvention key convention} to use.
+     * @throws IllegalArgumentException The given type is not serializable.
+     */
+    public ReflectTomlSerializer(
+            @NotNull Class<T> type,
+            @NotNull KeyConvention defaultConvention
+    ) throws IllegalArgumentException {
+        this(type, TypeAdapters.standard(), defaultConvention);
+    }
+
+    /**
+     * Create a new serializer for converting objects of the given
+     * type to/from a TOML table.
+     * @param type The table-like type to convert to/from.
+     * @param adapters Describes how leaves in the document tree may be converted to/from Java objects.
+     * @param defaultConvention The default {@link KeyConvention key convention} to use.
+     * @throws IllegalArgumentException The given type is not serializable.
+     */
+    public ReflectTomlSerializer(
+            @NotNull Class<T> type,
+            @NotNull TypeAdapters adapters,
+            @NotNull KeyConvention defaultConvention
+    ) throws IllegalArgumentException {
+        this(type, adapters, defaultConvention, C_SERIALIZE | C_DESERIALIZE);
     }
 
     ReflectTomlSerializer(
             @NotNull Class<T> type,
             @NotNull TypeAdapters adapters,
+            @NotNull KeyConvention defaultConvention,
             @MagicConstant(flags = { C_SERIALIZE, C_DESERIALIZE }) int capabilities
     ) {
         checkType(type, capabilities);
@@ -122,6 +159,7 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
         assert model != null;
         this.model = model;
         this.adapters = adapters;
+        this.defaultConvention = defaultConvention;
         this.capabilities = capabilities;
     }
 
@@ -197,15 +235,36 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
             @NotNull TableTypeModel<E> model,
             @NotNull TomlTable table
     ) {
+        TableTypeModel.Mapper mapper = model.mapper(this.defaultConvention);
         TableTypeModel.Builder<E> builder = model.create();
+        Map<TomlKey, TableTypeModel.Key> universe = mapper.universe();
 
-        for (TomlKey tk : table.keys(false)) {
-            TomlValue value = table.get(tk);
-            assert value != null;
+        if (universe != null) {
+            for (Map.Entry<TomlKey, TableTypeModel.Key> entry : universe.entrySet()) {
+                TomlValue value = table.get(entry.getKey());
+                if (value == null) {
+                    throw new IllegalArgumentException(
+                            "Table serialized as " + model.type().getName() +
+                            " does not contain key " + entry.getKey()
+                    );
+                }
 
-            TypeModel<?> valueModel = TypeModel.of(model.elementType(tk));
-            Object object = this.serializeValue(valueModel, value);
-            builder.set(tk, object);
+                TypeModel<?> valueModel = TypeModel.of(model.elementType(entry.getValue()));
+                Object object = this.serializeValue(valueModel, value);
+                builder.set(entry.getValue(), object);
+            }
+        } else {
+            for (TomlKey tk : table.keys(false)) {
+                TomlValue value = table.get(tk);
+                assert value != null;
+
+                TableTypeModel.Key key = mapper.fromTomlKey(tk);
+                if (key == null) continue;
+
+                TypeModel<?> valueModel = TypeModel.of(model.elementType(key));
+                Object object = this.serializeValue(valueModel, value);
+                builder.set(key, object);
+            }
         }
 
         return builder.build();
@@ -271,7 +330,7 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
 
         Object next;
         TomlValue nextValue;
-        for (TomlKey key : model.keys(value)) {
+        for (TableTypeModel.Key key : model.keys(value, this.defaultConvention)) {
             TypeModel<?> valueModel = TypeModel.of(model.elementType(key));
             next = model.get(value, key);
             nextValue = this.deserializeValueUnsafe(
@@ -280,7 +339,14 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
                     next
             );
             model.applyFieldComments(key, nextValue.comments());
-            ret.put(key, nextValue);
+            TomlKey tomlKey = key.asTomlKey();
+            TomlValue old = ret.put(tomlKey, nextValue);
+            if (old != null) {
+                throw new IllegalArgumentException(
+                        "Serializable type " + model.type().getName() +
+                        " defines key (" + tomlKey + ") more than once"
+                );
+            }
         }
 
         model.applyTableComments(ret.comments());

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializerService.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializerService.java
@@ -17,6 +17,7 @@
 package io.github.wasabithumb.jtoml.serial.reflect;
 
 import io.github.wasabithumb.jtoml.JToml;
+import io.github.wasabithumb.jtoml.option.JTomlOption;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.TomlSerializer;
 import io.github.wasabithumb.jtoml.serial.TomlSerializerService;
@@ -52,6 +53,7 @@ public final class ReflectTomlSerializerService extends TomlSerializerService {
         return new ReflectTomlSerializer<>(
                 outType,
                 TypeAdapters.standard(),
+                instance.options().get(JTomlOption.DEFAULT_KEY_CONVENTION),
                 ReflectTomlSerializer.C_SERIALIZE
         );
     }
@@ -61,6 +63,7 @@ public final class ReflectTomlSerializerService extends TomlSerializerService {
         return new ReflectTomlSerializer<>(
                 inType,
                 TypeAdapters.standard(),
+                instance.options().get(JTomlOption.DEFAULT_KEY_CONVENTION),
                 ReflectTomlSerializer.C_DESERIALIZE
         );
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
@@ -19,20 +19,32 @@ package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.comment.MultiComment;
+import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
+import io.github.wasabithumb.jtoml.serial.reflect.Convention;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 @ApiStatus.Internal
 abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
 
     @Contract(mutates = "param2")
     protected static void applyAnnotationComments(
-            @NotNull Annotation @NotNull [] annotations,
+            @NotNull AnnotatedElement annotated,
             @NotNull Comments comments
     ) {
+        Annotation[] annotations = annotated.getDeclaredAnnotations();
         for (Annotation a : annotations) {
             Class<?> decl = a.annotationType().getDeclaringClass();
             if (decl == null) continue;
@@ -60,6 +72,146 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
                 }
             }
         }
+    }
+
+    //
+
+    protected static abstract class AbstractKey implements Key {
+
+        @Override
+        public int hashCode() {
+            return this.asTomlKey().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Key)) return false;
+            return this.asTomlKey().equals(((Key) obj).asTomlKey());
+        }
+
+        @Override
+        public String toString() {
+            return this.asTomlKey().toString();
+        }
+
+    }
+
+    protected static abstract class MemberKey<M extends Member & AnnotatedElement> extends AbstractKey {
+
+        protected final M member;
+        protected final KeyConvention defaultConvention;
+
+        MemberKey(
+                @NotNull M member,
+                @NotNull KeyConvention defaultConvention
+        ) {
+            this.member = member;
+            this.defaultConvention = defaultConvention;
+        }
+
+        //
+
+        @Override
+        public @NotNull TomlKey asTomlKey() {
+            io.github.wasabithumb.jtoml.serial.reflect.Key explicitAnnotation = this.member
+                    .getDeclaredAnnotation(io.github.wasabithumb.jtoml.serial.reflect.Key.class);
+            if (explicitAnnotation != null) return TomlKey.literal(explicitAnnotation.value());
+
+            KeyConvention convention = determineConvention(this.member, this.defaultConvention);
+            return convention.toToml(this.member.getName());
+        }
+
+        //
+
+        private static <M extends Member & AnnotatedElement> @NotNull KeyConvention determineConvention(
+                @NotNull M member,
+                @NotNull KeyConvention defaultConvention
+        ) {
+            Class<?> declaringClass = member.getDeclaringClass();
+            Annotation[] a = member.getDeclaredAnnotations();
+            Annotation[] b = declaringClass.getDeclaredAnnotations();
+            final int al = a.length;
+            final int tl = al + b.length;
+
+            for (int i = 0; i < tl; i++) {
+                Annotation next = i < al ? a[i] : b[i - al];
+                if (next instanceof Convention) return ((Convention) next).value();
+                Class<? extends Annotation> annotationType = next.annotationType();
+                if (!Convention.class.equals(annotationType.getDeclaringClass())) continue;
+                return resolveConventionHelperAnnotation(annotationType);
+            }
+
+            return defaultConvention;
+        }
+
+        private static @NotNull KeyConvention resolveConventionHelperAnnotation(Class<? extends Annotation> type) {
+            Field field;
+            try {
+                field = type.getDeclaredField("VALUE");
+            } catch (NoSuchFieldException e) {
+                throw new IllegalStateException("Convention helper annotation " +
+                        type.getName() + " is missing required static field VALUE", e);
+            }
+            if (!KeyConvention.class.isAssignableFrom(field.getType())) {
+                throw new IllegalStateException("VALUE field for convention helper annotation " +
+                        type.getName() + " is not of type KeyConvention (is " + field.getType().getName() + ")");
+            }
+            KeyConvention value;
+            try {
+                value = (KeyConvention) field.get(null);
+            } catch (Exception e) {
+                throw new IllegalStateException(
+                        "Failed to read VALUE field on convention helper annotation " + type.getName(),
+                        e
+                );
+            }
+            return value;
+        }
+
+    }
+
+    protected static final class FixedMapper implements Mapper {
+
+        private final Map<TomlKey, Key> map;
+
+        FixedMapper(
+                @NotNull TableTypeModel<?> model,
+                @NotNull Collection<? extends Key> keys
+        ) {
+            this.map = buildMap(model, keys);
+        }
+
+        //
+
+        @Override
+        public @NotNull Map<TomlKey, Key> universe() {
+            return this.map;
+        }
+
+        @Override
+        public @Nullable Key fromTomlKey(@NotNull TomlKey key) {
+            return this.map.get(key);
+        }
+
+        //
+
+        private static @NotNull Map<TomlKey, Key> buildMap(
+                @NotNull TableTypeModel<?> model,
+                @NotNull Collection<? extends Key> keys
+        ) {
+            Map<TomlKey, Key> ret = new HashMap<>(keys.size());
+            for (Key key : keys) {
+                TomlKey tomlKey = key.asTomlKey();
+                Key existing = ret.put(tomlKey, key);
+                if (existing == null) continue;
+                throw new IllegalStateException(
+                        "Serializable type " + model.type().getName() +
+                                " declares duplicate key " + tomlKey
+                );
+            }
+            return Collections.unmodifiableMap(ret);
+        }
+
     }
 
 }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
@@ -17,8 +17,7 @@
 package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.comment.Comments;
-import io.github.wasabithumb.jtoml.key.TomlKey;
-import io.github.wasabithumb.jtoml.serial.reflect.Key;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
 import io.github.wasabithumb.recsup.RecordClass;
 import io.github.wasabithumb.recsup.RecordComponent;
@@ -35,31 +34,30 @@ import java.util.*;
 @ApiStatus.Internal
 final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
 
-    private static @NotNull Map<TomlKey, RecordComponent> buildComponentMap(@NotNull RecordClass<?> cls) {
-        Map<TomlKey, RecordComponent> ret = new HashMap<>();
-        for (RecordComponent rc : cls.getRecordComponents()) {
-            String name = rc.getName();
-            Key annotation = rc.getAccessor().getAnnotation(Key.class);
-            if (annotation != null) name = annotation.value();
-            TomlKey key = TomlKey.literal(name);
-            RecordComponent existing = ret.get(key);
-            if (existing != null) {
-                throw new IllegalStateException("Record component (" + rc.getName() + ") defined with key " + key +
-                        " shadows existing component (" + existing.getName() + ") defined with same key");
-            }
-            ret.put(key, rc);
+    private static @NotNull Key recordComponentKey(
+            @NotNull RecordComponent component,
+            @NotNull KeyConvention defaultConvention
+    ) {
+        return new RecordComponentKey(component, defaultConvention);
+    }
+
+    private static @NotNull RecordComponent unwrapRecordComponentKey(
+            @NotNull Key key
+    ) {
+        if (key instanceof RecordComponentKey) {
+            return ((RecordComponentKey) key).component;
         }
-        return Collections.unmodifiableMap(ret);
+        throw new IllegalArgumentException("Key " + key + " is not a RecordComponentKey");
     }
 
     //
 
     private final RecordClass<T> clazz;
-    private final Map<TomlKey, RecordComponent> components;
+    private final RecordComponent[] components;
 
     RecordTableTypeModel(@NotNull Class<T> clazz) {
         this.clazz = RecordSupport.asRecord(clazz);
-        this.components = buildComponentMap(this.clazz);
+        this.components = this.clazz.getRecordComponents();
     }
 
     //
@@ -75,30 +73,31 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
     }
 
     @Override
-    public @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull T instance) {
-        return this.components.keySet();
-    }
-
-    private @NotNull RecordComponent lookupComponent(@NotNull TomlKey key) {
-        if (key.size() != 1)
-            throw new IllegalArgumentException("Invalid key size (expected 1, got " + key.size() + ")");
-
-        RecordComponent rc = this.components.get(key);
-        if (rc != null) return rc;
-
-        throw new IllegalArgumentException("Record " + this.clazz.handle().getName() +
-                " has no component with key " + key.get(0));
+    public @NotNull Mapper mapper(@NotNull KeyConvention defaultConvention) {
+        return new FixedMapper(this, this.keys(defaultConvention));
     }
 
     @Override
-    public @NotNull ParameterizedClass<?> elementType(@NotNull TomlKey key) {
-        RecordComponent rc = this.lookupComponent(key);
-        return new ParameterizedClass<>(rc.getType(), rc.getGenericType());
+    public @NotNull @Unmodifiable Collection<Key> keys(@NotNull T instance, @NotNull KeyConvention defaultConvention) {
+        return this.keys(defaultConvention);
+    }
+
+    private @NotNull @Unmodifiable Collection<Key> keys(@NotNull KeyConvention defaultConvention) {
+        List<Key> ret = new ArrayList<>(this.components.length);
+        for (RecordComponent rc : this.components) ret.add(recordComponentKey(rc, defaultConvention));
+        return Collections.unmodifiableList(ret);
     }
 
     @Override
-    public @UnknownNullability Object get(@NotNull T instance, @NotNull TomlKey key) {
-        Method m = this.lookupComponent(key).getAccessor();
+    public @NotNull ParameterizedClass<?> elementType(@NotNull Key key) {
+        final RecordComponent componentKey = unwrapRecordComponentKey(key);
+        return new ParameterizedClass<>(componentKey.getType(), componentKey.getGenericType());
+    }
+
+    @Override
+    public @UnknownNullability Object get(@NotNull T instance, @NotNull Key key) {
+        final RecordComponent component = unwrapRecordComponentKey(key);
+        final Method m = component.getAccessor();
         try {
             return m.invoke(instance);
         } catch (InvocationTargetException | ExceptionInInitializerError e) {
@@ -113,13 +112,13 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
 
     @Override
     public void applyTableComments(@NotNull Comments comments) {
-        applyAnnotationComments(this.clazz.handle().getDeclaredAnnotations(), comments);
+        applyAnnotationComments(this.clazz.handle(), comments);
     }
 
     @Override
-    public void applyFieldComments(@NotNull TomlKey key, @NotNull Comments comments) {
-        RecordComponent component = this.lookupComponent(key);
-        applyAnnotationComments(component.getAccessor().getDeclaredAnnotations(), comments);
+    public void applyFieldComments(@NotNull Key key, @NotNull Comments comments) {
+        final RecordComponent component = unwrapRecordComponentKey(key);
+        applyAnnotationComments(component.getAccessor(), comments);
     }
 
     //
@@ -131,14 +130,14 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
 
         private Builder(@NotNull RecordTableTypeModel<O> parent) {
             this.parent = parent;
-            this.values = new Object[parent.components.size()];
+            this.values = new Object[parent.components.length];
         }
 
         //
 
         @Override
-        public void set(@NotNull TomlKey key, @NotNull Object value) {
-            RecordComponent component = this.parent.lookupComponent(key);
+        public void set(@NotNull Key key, @NotNull Object value) {
+            final RecordComponent component = unwrapRecordComponentKey(key);
             this.values[component.index()] = value;
         }
 
@@ -154,6 +153,20 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
             } catch (ReflectiveOperationException e) {
                 throw new AssertionError("Unexpected reflection error", e);
             }
+        }
+
+    }
+
+    private static final class RecordComponentKey extends MemberKey<Method> {
+
+        private final RecordComponent component;
+
+        RecordComponentKey(
+                @NotNull RecordComponent component,
+                @NotNull KeyConvention defaultConvention
+        ) {
+            super(component.getAccessor(), defaultConvention);
+            this.component = component;
         }
 
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
@@ -17,9 +17,8 @@
 package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.comment.Comments;
-import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
-import io.github.wasabithumb.jtoml.serial.reflect.Key;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
 import org.jetbrains.annotations.*;
 
@@ -28,6 +27,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 @ApiStatus.Internal
 final class SerializableTableTypeModel<T extends TomlSerializable> extends AbstractTableTypeModel<T> {
@@ -37,44 +39,58 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
         return new SerializableTableTypeModel<>(cls.asSubclass(TomlSerializable.class));
     }
 
-    private static @NotNull Map<TomlKey, Field> buildFieldMap(@NotNull Class<?> cls) {
-        Map<TomlKey, Field> ret = new HashMap<>();
-        buildFieldMap0(cls, ret);
-        return Collections.unmodifiableMap(ret);
+    private static @NotNull Spliterator<Class<?>> hierarchy(final @NotNull Class<?> base) {
+        final Iterator<Class<?>> src = new Iterator<Class<?>>() {
+            private Class<?> next = base;
+
+            @Override
+            public boolean hasNext() {
+                return this.next != null && TomlSerializable.class.isAssignableFrom(this.next);
+            }
+
+            @Override
+            public Class<?> next() {
+                Class<?> ret = this.next;
+                this.next = ret.getSuperclass();
+                return ret;
+            }
+        };
+        return Spliterators.spliteratorUnknownSize(
+                src,
+                Spliterator.DISTINCT |
+                        Spliterator.ORDERED |
+                        Spliterator.NONNULL |
+                        Spliterator.IMMUTABLE
+        );
     }
 
-    private static void buildFieldMap0(@NotNull Class<?> cls, @NotNull Map<TomlKey, Field> map) {
-        for (Field f : cls.getDeclaredFields()) {
-            int mod = f.getModifiers();
-            if (Modifier.isStatic(mod) || Modifier.isTransient(mod)) continue;
-            buildFieldMap00(f, map);
-        }
-        cls = cls.getSuperclass();
-        if (cls == null || !TomlSerializable.class.isAssignableFrom(cls)) return;
-        buildFieldMap0(cls, map);
+    private static @NotNull Stream<Field> fieldStream(final @NotNull Class<?> clazz) {
+        return StreamSupport.stream(hierarchy(clazz), false)
+                .flatMap((Class<?> cls) -> Stream.of(cls.getDeclaredFields()))
+                .filter((Field f) -> {
+                    if (f.isSynthetic()) return false;
+                    final int mod = f.getModifiers();
+                    return !Modifier.isStatic(mod) && !Modifier.isTransient(mod);
+                });
     }
 
-    private static void buildFieldMap00(@NotNull Field f, @NotNull Map<TomlKey, Field> map) {
-        String name = f.getName();
-        Key annotation = f.getAnnotation(Key.class);
-        if (annotation != null) name = annotation.value();
-        TomlKey key = TomlKey.literal(name);
-        Field existing = map.put(key, f);
-        if (existing != null) {
-            throw new IllegalStateException("Serializable field (" + f.getName() + ") with key " + key +
-                    " shadows field (" + existing.getName() + ") with same key declared in class " +
-                    existing.getDeclaringClass().getName());
+    private static @NotNull Key fieldKey(@NotNull Field field, @NotNull KeyConvention defaultConvention) {
+        return new FieldKey(field, defaultConvention);
+    }
+
+    private static @NotNull Field unwrapFieldKey(@NotNull Key key) {
+        if (key instanceof FieldKey) {
+            return ((FieldKey) key).member;
         }
+        throw new IllegalArgumentException("Key " + key + " is not a FieldKey");
     }
 
     //
 
     private final Class<T> type;
-    private final Map<TomlKey, Field> fieldMap;
 
     private SerializableTableTypeModel(@NotNull Class<T> type) {
         this.type = type;
-        this.fieldMap = buildFieldMap(type);
     }
 
     //
@@ -121,30 +137,29 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
     }
 
     @Override
-    public @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull T instance) {
-        return this.fieldMap.keySet();
-    }
-
-    private @NotNull Field resolveField(@NotNull TomlKey key) {
-        if (key.size() != 1)
-            throw new IllegalArgumentException("Illegal key size (expected 1, got " + key.size() + ")");
-
-        Field ret = this.fieldMap.get(key);
-        if (ret != null) return ret;
-
-        throw new IllegalArgumentException(
-                "Key \"" + key.get(0) + "\" does not match any fields on TomlSerializable type " + this.type.getName()
-        );
+    public @NotNull Mapper mapper(@NotNull KeyConvention defaultConvention) {
+        return new FixedMapper(this, this.keys(this.type, defaultConvention));
     }
 
     @Override
-    public @NotNull ParameterizedClass<?> elementType(@NotNull TomlKey key) {
-        return ParameterizedClass.of(this.resolveField(key));
+    public @NotNull @Unmodifiable Collection<Key> keys(@NotNull T instance, @NotNull KeyConvention defaultConvention) {
+        return this.keys(instance.getClass(), defaultConvention);
+    }
+
+    private @NotNull @Unmodifiable Collection<Key> keys(@NotNull Class<?> type, @NotNull KeyConvention defaultConvention) {
+        return fieldStream(type)
+                .map((Field f) -> fieldKey(f, defaultConvention))
+                .collect(Collectors.toList());
     }
 
     @Override
-    public @UnknownNullability Object get(@NotNull T instance, @NotNull TomlKey key) {
-        Field f = this.resolveField(key);
+    public @NotNull ParameterizedClass<?> elementType(@NotNull Key key) {
+        return ParameterizedClass.of(unwrapFieldKey(key));
+    }
+
+    @Override
+    public @UnknownNullability Object get(@NotNull T instance, @NotNull Key key) {
+        Field f = unwrapFieldKey(key);
 
         Throwable suppressed = null;
         try {
@@ -165,13 +180,13 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
 
     @Override
     public void applyTableComments(@NotNull Comments comments) {
-        applyAnnotationComments(this.type.getDeclaredAnnotations(), comments);
+        applyAnnotationComments(this.type, comments);
     }
 
     @Override
-    public void applyFieldComments(@NotNull TomlKey key, @NotNull Comments comments) {
-        Field f = this.resolveField(key);
-        applyAnnotationComments(f.getDeclaredAnnotations(), comments);
+    public void applyFieldComments(@NotNull Key key, @NotNull Comments comments) {
+        Field f = unwrapFieldKey(key);
+        applyAnnotationComments(f, comments);
     }
 
     //
@@ -195,8 +210,8 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
         }
 
         @Override
-        public void set(@NotNull TomlKey key, @NotNull Object value) {
-            Field f = this.parent.resolveField(key);
+        public void set(@NotNull Key key, @NotNull Object value) {
+            Field f = unwrapFieldKey(key);
 
             Throwable suppressed = null;
             try {
@@ -226,6 +241,17 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
         @Override
         public @NotNull O build() {
             return this.instance;
+        }
+
+    }
+
+    private static final class FieldKey extends MemberKey<Field> {
+
+        FieldKey(
+                @NotNull Field field,
+                @NotNull KeyConvention defaultConvention
+        ) {
+            super(field, defaultConvention);
         }
 
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/StringMapTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/StringMapTableTypeModel.java
@@ -17,11 +17,9 @@
 package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.UnknownNullability;
-import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.*;
 
 import java.util.*;
 
@@ -36,6 +34,17 @@ final class StringMapTableTypeModel<T extends Map<String, V>, V> extends Abstrac
         return new StringMapTableTypeModel<>(mapClass, (ParameterizedClass<IV>) valueType);
     }
 
+    private static @NotNull Key stringKey(@NotNull String value) {
+        return new StringKey(value);
+    }
+
+    private static @NotNull String unwrapStringKey(@NotNull Key key) throws IllegalArgumentException {
+        if (key instanceof StringKey) {
+            return ((StringKey) key).value;
+        }
+        throw new IllegalArgumentException("Key " + key + " is not a StringKey");
+    }
+    
     //
 
     private final Class<T> clazz;
@@ -74,24 +83,26 @@ final class StringMapTableTypeModel<T extends Map<String, V>, V> extends Abstrac
     }
 
     @Override
-    public @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull T instance) {
+    public @NotNull Mapper mapper(@NotNull KeyConvention defaultConvention) {
+        return StringMapper.INSTANCE;
+    }
+
+    @Override
+    public @NotNull @Unmodifiable Collection<Key> keys(@NotNull T instance, @NotNull KeyConvention convention) {
         Set<String> keys = instance.keySet();
-        List<TomlKey> ret = new ArrayList<>(keys.size());
-        for (String key : keys) ret.add(TomlKey.literal(key));
+        List<Key> ret = new ArrayList<>(keys.size());
+        for (String key : keys) ret.add(stringKey(key));
         return Collections.unmodifiableList(ret);
     }
 
     @Override
-    public @NotNull ParameterizedClass<?> elementType(@NotNull TomlKey key) {
+    public @NotNull ParameterizedClass<?> elementType(@NotNull Key ignored) {
         return this.valueType;
     }
 
     @Override
-    public @UnknownNullability Object get(@NotNull T instance, @NotNull TomlKey key) {
-        if (key.size() != 1)
-            throw new IllegalArgumentException("Illegal key size (expected 1, got " + key.size() + ")");
-
-        return instance.get(key.get(0));
+    public @UnknownNullability Object get(@NotNull T instance, @NotNull Key key) {
+        return instance.get(unwrapStringKey(key));
     }
 
     //
@@ -109,16 +120,42 @@ final class StringMapTableTypeModel<T extends Map<String, V>, V> extends Abstrac
         //
 
         @Override
-        public void set(@NotNull TomlKey key, @NotNull Object value) {
-            if (key.size() != 1)
-                throw new IllegalArgumentException("Illegal key size (expected 1, got " + key.size() + ")");
-
-            this.map.put(key.get(0), this.parent.valueType.raw().cast(value));
+        public void set(@NotNull Key key, @NotNull Object value) {
+            this.map.put(unwrapStringKey(key), this.parent.valueType.raw().cast(value));
         }
 
         @Override
         public @NotNull T build() {
             return this.map;
+        }
+
+    }
+
+    private static final class StringKey extends AbstractKey {
+
+        private final String value;
+
+        StringKey(@NotNull String value) {
+            this.value = value;
+        }
+
+        //
+
+        @Override
+        public @NotNull TomlKey asTomlKey() {
+            return TomlKey.literal(this.value);
+        }
+
+    }
+
+    private static final class StringMapper implements Mapper {
+
+        static final StringMapper INSTANCE = new StringMapper();
+
+        @Override
+        public @NotNull Key fromTomlKey(@NotNull TomlKey key) {
+            if (key.size() != 1) throw new IllegalStateException("TOML key should have 1 part when associated with string map (got " + key + ")");
+            return new StringKey(key.get(0));
         }
 
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TableTypeModel.java
@@ -18,6 +18,7 @@ package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.reflect.model.TypeModel;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
@@ -48,7 +49,7 @@ public interface TableTypeModel<T> extends TypeModel<T> {
 
         // Map<String, ?>
         ParameterizedClass<?> mt = pc.declaredInterface(Map.class);
-        if (mt != null && mt.paramCount() >= 2 && String.class.equals(mt.param(0))) {
+        if (mt != null && mt.paramCount() == 2 && String.class.equals(mt.param(0))) {
             ParameterizedClass<?> vt = ParameterizedClass.of(mt.param(1));
             return (TableTypeModel<O>) StringMapTableTypeModel.create(raw.asSubclass(Map.class), vt);
         }
@@ -61,24 +62,54 @@ public interface TableTypeModel<T> extends TypeModel<T> {
 
     @NotNull Builder<T> create();
 
-    @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull T instance);
+    @NotNull Mapper mapper(@NotNull KeyConvention defaultConvention);
 
-    @NotNull ParameterizedClass<?> elementType(@NotNull TomlKey key);
+    /**
+     * @apiNote This is often an expensive operation.
+     * The intent is to call this method ONCE to build a map.
+     */
+    @NotNull @Unmodifiable Collection<? extends Key> keys(@NotNull T instance, @NotNull KeyConvention defaultConvention);
 
-    @UnknownNullability Object get(@NotNull T instance, @NotNull TomlKey key);
+    @NotNull ParameterizedClass<?> elementType(@NotNull Key key);
+
+    @UnknownNullability Object get(@NotNull T instance, @NotNull Key key);
 
     default void applyTableComments(@NotNull Comments comments) { }
 
     @Contract(mutates = "param2")
-    default void applyFieldComments(@NotNull TomlKey key, @NotNull Comments comments) { }
+    default void applyFieldComments(@NotNull Key key, @NotNull Comments comments) { }
 
     //
 
     interface Builder<O> {
 
-        void set(@NotNull TomlKey key, @NotNull Object value);
+        void set(@NotNull Key key, @NotNull Object value);
 
         @NotNull O build();
+
+    }
+
+    /**
+     * Exists to allow the original representation
+     * of the key to be retained by implementers
+     */
+    interface Key {
+
+        @NotNull TomlKey asTomlKey();
+
+        default boolean matches(@NotNull TomlKey other) {
+            return this.asTomlKey().equals(other);
+        }
+
+    }
+
+    interface Mapper {
+
+        @Nullable Key fromTomlKey(@NotNull TomlKey key);
+
+        default @Nullable Map<TomlKey, Key> universe() {
+            return null;
+        }
 
     }
 

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TomlTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TomlTableTypeModel.java
@@ -17,15 +17,16 @@
 package io.github.wasabithumb.jtoml.serial.reflect.model.table;
 
 import io.github.wasabithumb.jtoml.key.TomlKey;
+import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.util.ParameterizedClass;
 import io.github.wasabithumb.jtoml.value.TomlValue;
 import io.github.wasabithumb.jtoml.value.table.TomlTable;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.UnknownNullability;
-import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.*;
 
+import java.util.AbstractSet;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
 
 @ApiStatus.Internal
 final class TomlTableTypeModel extends AbstractTableTypeModel<TomlTable> {
@@ -45,18 +46,23 @@ final class TomlTableTypeModel extends AbstractTableTypeModel<TomlTable> {
     }
 
     @Override
-    public @NotNull @Unmodifiable Collection<TomlKey> keys(@NotNull TomlTable instance) {
-        return instance.keys(false);
+    public @NotNull Mapper mapper(@NotNull KeyConvention defaultConvention) {
+        return LiteralMapper.INSTANCE;
     }
 
     @Override
-    public @NotNull ParameterizedClass<?> elementType(@NotNull TomlKey key) {
+    public @NotNull @Unmodifiable Collection<Key> keys(@NotNull TomlTable instance, @NotNull KeyConvention ignored) {
+        return new KeySet(instance.keys(false));
+    }
+
+    @Override
+    public @NotNull ParameterizedClass<?> elementType(@NotNull Key key) {
         return new ParameterizedClass<>(TomlValue.class);
     }
 
     @Override
-    public @UnknownNullability Object get(@NotNull TomlTable instance, @NotNull TomlKey key) {
-        return instance.get(key);
+    public @UnknownNullability Object get(@NotNull TomlTable instance, @NotNull Key key) {
+        return instance.get(key.asTomlKey());
     }
 
     //
@@ -66,13 +72,71 @@ final class TomlTableTypeModel extends AbstractTableTypeModel<TomlTable> {
         private final TomlTable table = TomlTable.create();
 
         @Override
-        public void set(@NotNull TomlKey key, @NotNull Object value) {
-            this.table.put(key, (TomlValue) value);
+        public void set(@NotNull Key key, @NotNull Object value) {
+            this.table.put(key.asTomlKey(), (TomlValue) value);
         }
 
         @Override
         public @NotNull TomlTable build() {
             return this.table;
+        }
+
+    }
+
+    private static final class LiteralKey extends AbstractKey {
+
+        private final TomlKey value;
+
+        LiteralKey(@NotNull TomlKey value) {
+            this.value = value;
+        }
+
+        //
+
+        @Override
+        public @NotNull TomlKey asTomlKey() {
+            return this.value;
+        }
+
+    }
+
+    private static final class LiteralMapper implements Mapper {
+
+        private static final LiteralMapper INSTANCE = new LiteralMapper();
+
+        @Override
+        public @NotNull Key fromTomlKey(@NotNull TomlKey key) {
+            return new LiteralKey(key);
+        }
+
+    }
+
+    private static final class KeySet extends AbstractSet<Key> {
+
+        private final Set<TomlKey> backing;
+
+        KeySet(@NotNull Set<TomlKey> backing) {
+            this.backing = backing;
+        }
+
+        //
+
+        @Override
+        public int size() {
+            return this.backing.size();
+        }
+
+        @Override
+        public Iterator<Key> iterator() {
+            return this.backing.stream()
+                    .map((TomlKey tk) -> (Key) new LiteralKey(tk))
+                    .iterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            if (!(o instanceof Key)) return false;
+            return this.backing.contains(((Key) o).asTomlKey());
         }
 
     }

--- a/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
+++ b/src/main/java/io/github/wasabithumb/jtoml/JTomlImpl.java
@@ -69,6 +69,11 @@ final class JTomlImpl implements JToml {
         return JTomlVersionInfo.derivedVersion();
     }
 
+    @Override
+    public @NotNull JTomlOptions options() {
+        return this.options;
+    }
+
     private @NotNull TomlTable read(@NotNull BufferedCharSource cs) throws TomlException {
         TableReader tr = new TableReader(cs, this.options);
         return tr.readTable();

--- a/src/test/java17/io/github/wasabithumb/jtoml/JTomlTest.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/JTomlTest.java
@@ -20,14 +20,14 @@ import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.comment.CommentPosition;
 import io.github.wasabithumb.jtoml.comment.Comments;
 import io.github.wasabithumb.jtoml.document.TomlDocument;
-import io.github.wasabithumb.jtoml.dummy.Named;
-import io.github.wasabithumb.jtoml.dummy.NamedTriplet;
-import io.github.wasabithumb.jtoml.dummy.RecordTable;
+import io.github.wasabithumb.jtoml.dummy.*;
 import io.github.wasabithumb.jtoml.except.TomlException;
 import io.github.wasabithumb.jtoml.except.TomlValueException;
 import io.github.wasabithumb.jtoml.except.parse.TomlParseException;
 import io.github.wasabithumb.jtoml.key.TomlKey;
-import io.github.wasabithumb.jtoml.dummy.PojoTable;
+import io.github.wasabithumb.jtoml.key.convention.StandardKeyConvention;
+import io.github.wasabithumb.jtoml.option.JTomlOption;
+import io.github.wasabithumb.jtoml.option.JTomlOptions;
 import io.github.wasabithumb.jtoml.serial.reflect.ReflectTomlSerializer;
 import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapter;
 import io.github.wasabithumb.jtoml.serial.reflect.adapter.TypeAdapters;
@@ -118,6 +118,27 @@ class JTomlTest {
         assertTrue(toml.contains("local-date"));
         assertFalse(toml.contains("localDate"));
         RecordTable out = TOML.fromToml(RecordTable.class, toml);
+        assertEquals(original, out);
+    }
+
+    @Test
+    void trickyConvention() {
+        JToml toml = JToml.jToml(JTomlOptions.builder()
+                .set(JTomlOption.DEFAULT_KEY_CONVENTION, StandardKeyConvention.SNAKE)
+                .build());
+
+        TrickyConvention original = TrickyConvention.create();
+        TomlTable table = toml.toToml(original);
+        System.out.println(toml.writeToString(table));
+
+        assertTrue(table.contains("literalInt"));
+        assertTrue(table.contains("lowerint"));
+        assertTrue(table.contains("defaulting_int"));
+        assertTrue(table.contains("kebab-int"));
+        assertTrue(table.contains("split.int"));
+        assertTrue(table.contains("custom"));
+
+        TrickyConvention out = toml.fromToml(TrickyConvention.class, table);
         assertEquals(original, out);
     }
 

--- a/src/test/java17/io/github/wasabithumb/jtoml/dummy/PojoTable.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/dummy/PojoTable.java
@@ -19,6 +19,7 @@ package io.github.wasabithumb.jtoml.dummy;
 import io.github.wasabithumb.jtoml.Faker;
 import io.github.wasabithumb.jtoml.comment.Comment;
 import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+import io.github.wasabithumb.jtoml.serial.reflect.Convention;
 import io.github.wasabithumb.jtoml.serial.reflect.Key;
 
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 
+@Convention.Kebab
 public final class PojoTable implements TomlSerializable {
 
     public static PojoTable create() {
@@ -36,23 +38,12 @@ public final class PojoTable implements TomlSerializable {
 
     //
 
-    @Comment.Inline("Some text")
-    public String text;
-
+    @Comment.Inline("Some text") public String text;
     public long integer;
-
     public double decimal;
-
-    @Key("local-date")
     public LocalDate localDate;
-
-    @Key("local-time")
     public LocalTime localTime;
-
-    @Key("local-date-time")
     public LocalDateTime localDateTime;
-
-    @Key("offset-date-time")
     public OffsetDateTime offsetDateTime;
 
     public transient short redHerring;

--- a/src/test/java17/io/github/wasabithumb/jtoml/dummy/RecordTable.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/dummy/RecordTable.java
@@ -18,6 +18,7 @@ package io.github.wasabithumb.jtoml.dummy;
 
 import io.github.wasabithumb.jtoml.Faker;
 import io.github.wasabithumb.jtoml.comment.Comment;
+import io.github.wasabithumb.jtoml.serial.reflect.Convention;
 import io.github.wasabithumb.jtoml.serial.reflect.Key;
 
 import java.time.LocalDate;
@@ -25,24 +26,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 
+@Convention.Kebab
 public record RecordTable(
-        @Comment.Inline("Some text")
-        String text,
-
+        @Comment.Inline("Some text") String text,
         long integer,
-
         double decimal,
-
-        @Key("local-date")
         LocalDate localDate,
-
-        @Key("local-time")
         LocalTime localTime,
-
-        @Key("local-date-time")
         LocalDateTime localDateTime,
-
-        @Key("offset-date-time")
         OffsetDateTime offsetDateTime
 ) {
 

--- a/src/test/java17/io/github/wasabithumb/jtoml/dummy/TrickyConvention.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/dummy/TrickyConvention.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.wasabithumb.jtoml.dummy;
 
 import io.github.wasabithumb.jtoml.Faker;

--- a/src/test/java17/io/github/wasabithumb/jtoml/dummy/TrickyConvention.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/dummy/TrickyConvention.java
@@ -1,0 +1,36 @@
+package io.github.wasabithumb.jtoml.dummy;
+
+import io.github.wasabithumb.jtoml.Faker;
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
+import io.github.wasabithumb.jtoml.serial.reflect.Convention;
+import io.github.wasabithumb.jtoml.serial.reflect.Key;
+
+public final class TrickyConvention implements TomlSerializable {
+
+    public static TrickyConvention create() {
+        return Faker.create(TrickyConvention.class);
+    }
+
+    //
+
+    @Convention.Literal public int literalInt;
+    @Convention.Lower public int lowerInt;
+    public int defaultingInt;
+    @Convention.Kebab public int kebabInt;
+    @Convention.Split public int splitInt;
+    @Key("custom") public int customInt;
+
+    //
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof TrickyConvention other)) return false;
+        return this.literalInt == other.literalInt &&
+                this.lowerInt == other.lowerInt &&
+                this.defaultingInt == other.defaultingInt &&
+                this.kebabInt == other.kebabInt &&
+                this.splitInt == other.splitInt &&
+                this.customInt == other.customInt;
+    }
+
+}


### PR DESCRIPTION
Will resolve #60. Adds ``@Convention`` and ``JTomlOption.DEFAULT_KEY_CONVENTION`` to control how fields are mapped by the reflect serializer into TOML keys in absence of a ``@Key`` annotation. This entails some rethinking of the table models used by the reflect serializer that I believe will be ultimately good for consistency. When a table model corresponds to a POJO/record, deserialization is now driven by the appropriate fields/records. Before this refactor, we would iterate over each key that happens to be in the table and assume it can be mapped to a field/record. Since this changes the behavior of the serializer- even if only in edge cases- this needs to be tested thoroughly.
