### PR TITLE
Add defaulting annotation for reflect serialization

### DIFF
--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Defaulting.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/Defaulting.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.wasabithumb.jtoml.serial.reflect;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>
+ *     Annotation for use in {@link io.github.wasabithumb.jtoml.serial.TomlSerializable reflect serialization}.
+ *     Permits partial resolution of a serializable type. When applied to a single field/component, the matching
+ *     key does not have to exist in the source document. When applied to the type itself,
+ *     none of its fields/components have to exist in the source document.
+ * </p>
+ * <p>
+ *     When an optional specific subtype is used, a default value may be specified.
+ *     This covers all types which may be used as an annotation parameter per
+ *     JVM restrictions:
+ * </p>
+ * <table>
+ *     <caption>Optional Specific Subtypes</caption>
+ *     <tr>
+ *         <th>Annotation</th>
+ *         <th>Applicable Types</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link ToString @Defaulting.ToString}</td>
+ *         <td>{@code String}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link ToInt @Defaulting.ToInt}</td>
+ *         <td>{@code byte}, {@code short}, {@code int}, {@code long}, {@code char} and boxed variants</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link ToFloat @Defaulting.ToFloat}</td>
+ *         <td>{@code float}, {@code double} and boxed variants</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link ToBool @Defaulting.ToBool}</td>
+ *         <td>{@code boolean} and boxed variant</td>
+ *     </tr>
+ * </table>
+ * <p>
+ *     For <strong>record components</strong> with <strong>no mapping</strong>
+ *     and <strong>in absence of an optional specific subtype</strong>,
+ *     the "default value" for that type is injected. This coincides
+ *     with how the compiler tends to resolve uninitialized fields,
+ *     shown below:
+ * </p>
+ * <table>
+ *     <caption>Default Values</caption>
+ *     <tr>
+ *         <th>Type</th>
+ *         <th>Default Value</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code byte}</td>
+ *         <td>{@code 0}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code short}</td>
+ *         <td>{@code 0}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code int}</td>
+ *         <td>{@code 0}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code long}</td>
+ *         <td>{@code 0L}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code float}</td>
+ *         <td>{@code 0f}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code double}</td>
+ *         <td>{@code 0d}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code char}</td>
+ *         <td>{@code (char) 0}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code boolean}</td>
+ *         <td>{@code false}</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@code Object}</td>
+ *         <td>{@code null}</td>
+ *     </tr>
+ * </table>
+ * <p>
+ *     For <strong>POJO fields</strong> with <strong>no mapping</strong>
+ *     and <strong>in absence of an optional specific subtype</strong>,
+ *     the field is left uninitialized. The field will retain the
+ *     value it has at initialization time.
+ * </p>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+public @interface Defaulting {
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    @interface ToString {
+        String value();
+    }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    @interface ToInt {
+        long value();
+    }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    @interface ToFloat {
+        double value();
+    }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    @interface ToBool {
+        boolean value();
+    }
+
+}

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/ReflectTomlSerializer.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Modifier;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Handles reflection-powered conversion of TOML tables
@@ -241,17 +242,24 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
 
         if (universe != null) {
             for (Map.Entry<TomlKey, TableTypeModel.Key> entry : universe.entrySet()) {
+                TableTypeModel.Key modelKey = entry.getValue();
                 TomlValue value = table.get(entry.getKey());
+
                 if (value == null) {
-                    throw new IllegalArgumentException(
-                            "Table serialized to " + model.type().getName() +
-                            " does not contain key " + entry.getKey()
-                    );
+                    if (!modelKey.isDefaulting()) {
+                        throw new IllegalArgumentException(
+                                "Table serialized to " + model.type().getName() +
+                                        " does not contain key " + entry.getKey()
+                        );
+                    }
+                    Object defaultValue = modelKey.defaultValue();
+                    if (defaultValue != null) builder.set(modelKey, defaultValue);
+                    continue;
                 }
 
-                TypeModel<?> valueModel = TypeModel.of(model.elementType(entry.getValue()));
+                TypeModel<?> valueModel = TypeModel.of(model.elementType(modelKey));
                 Object object = this.serializeValue(valueModel, value);
-                builder.set(entry.getValue(), object);
+                builder.set(modelKey, object);
             }
         } else {
             for (TomlKey tk : table.keys(false)) {
@@ -333,6 +341,13 @@ public final class ReflectTomlSerializer<T> implements TomlSerializer.Symmetric<
         for (TableTypeModel.Key key : model.keys(value, this.defaultConvention)) {
             TypeModel<?> valueModel = TypeModel.of(model.elementType(key));
             next = model.get(value, key);
+            if (key.isDefaulting() && Objects.equals(next, key.defaultValue())) continue;
+            if (next == null) {
+                throw new IllegalStateException(
+                        "Value for key " + key + " in instance of serializable type " +
+                        model.type().getName() + " is null (not the default value)"
+                );
+            }
             nextValue = this.deserializeValueUnsafe(
                     ReferenceHolder.copyOf(parents),
                     valueModel,

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/AbstractTableTypeModel.java
@@ -22,6 +22,7 @@ import io.github.wasabithumb.jtoml.comment.MultiComment;
 import io.github.wasabithumb.jtoml.key.TomlKey;
 import io.github.wasabithumb.jtoml.key.convention.KeyConvention;
 import io.github.wasabithumb.jtoml.serial.reflect.Convention;
+import io.github.wasabithumb.jtoml.serial.reflect.Defaulting;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,10 +32,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 @ApiStatus.Internal
 abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
@@ -100,6 +100,7 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
 
         protected final M member;
         protected final KeyConvention defaultConvention;
+        private final @Nullable Annotation defaultingAnnotation;
 
         MemberKey(
                 @NotNull M member,
@@ -107,9 +108,80 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
         ) {
             this.member = member;
             this.defaultConvention = defaultConvention;
+            this.defaultingAnnotation = findDefaultingAnnotation(member);
         }
 
         //
+
+        protected abstract Class<?> typeClassOf(M member);
+
+        protected abstract @Nullable Object nonSpecificDefault(Class<?> type);
+
+        @Override
+        public boolean isDefaulting() {
+            return this.defaultingAnnotation != null;
+        }
+
+        @Override
+        public @Nullable Object defaultValue() throws UnsupportedOperationException {
+            Annotation annotation = this.defaultingAnnotation;
+            if (annotation == null) throw new UnsupportedOperationException();
+            Class<?> typeClass = this.typeClassOf(this.member);
+
+            if (annotation instanceof Defaulting.ToInt) {
+                Defaulting.ToInt qual = (Defaulting.ToInt) annotation;
+                if (typeClass.equals(Byte.TYPE) || typeClass.equals(Byte.class)) {
+                    return (byte) qual.value();
+                } else if (typeClass.equals(Short.TYPE) || typeClass.equals(Short.class)) {
+                    return (short) qual.value();
+                } else if (typeClass.equals(Integer.TYPE) || typeClass.equals(Integer.class)) {
+                    return (int) qual.value();
+                } else if (typeClass.equals(Long.TYPE) || typeClass.equals(Long.class)) {
+                    return qual.value();
+                } else if (typeClass.equals(Character.TYPE) || typeClass.equals(Character.class)) {
+                    return (char) qual.value();
+                } else {
+                    throw new IllegalStateException(
+                            "@Defaulting.ToInt cannot be applied to element of type " +
+                            typeClass.getName() + " (" + this.member + ")"
+                    );
+                }
+            } else if (annotation instanceof Defaulting.ToFloat) {
+                Defaulting.ToFloat qual = (Defaulting.ToFloat) annotation;
+                if (typeClass.equals(Float.TYPE) || typeClass.equals(Float.class)) {
+                    return (float) qual.value();
+                } else if (typeClass.equals(Double.TYPE) || typeClass.equals(Double.class)) {
+                    return qual.value();
+                } else {
+                    throw new IllegalStateException(
+                            "@Defaulting.ToFloat cannot be applied to element of type " +
+                                    typeClass.getName() + " (" + this.member + ")"
+                    );
+                }
+            } else if (annotation instanceof Defaulting.ToBool) {
+                Defaulting.ToBool qual = (Defaulting.ToBool) annotation;
+                if (typeClass.equals(Boolean.TYPE) || typeClass.equals(Boolean.class)) {
+                    return qual.value();
+                } else {
+                    throw new IllegalStateException(
+                            "@Defaulting.ToBool cannot be applied to element of type " +
+                                    typeClass.getName() + " (" + this.member + ")"
+                    );
+                }
+            } else if (annotation instanceof Defaulting.ToString) {
+                Defaulting.ToString qual = (Defaulting.ToString) annotation;
+                if (typeClass.equals(String.class)) {
+                    return qual.value();
+                } else {
+                    throw new IllegalStateException(
+                            "@Defaulting.ToString cannot be applied to element of type " +
+                                    typeClass.getName() + " (" + this.member + ")"
+                    );
+                }
+            }
+
+            return this.nonSpecificDefault(typeClass);
+        }
 
         @Override
         public @NotNull TomlKey asTomlKey() {
@@ -123,24 +195,30 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
 
         //
 
+        private static <M extends Member & AnnotatedElement> @Nullable Annotation findDefaultingAnnotation(
+                M member
+        ) {
+            return memberAndDeclaringClassAnnotations(member)
+                    .filter((Annotation a) ->
+                            a instanceof Defaulting ||
+                            Defaulting.class.equals(a.annotationType().getDeclaringClass())
+                    )
+                    .findFirst()
+                    .orElse(null);
+        }
+
         private static <M extends Member & AnnotatedElement> @NotNull KeyConvention determineConvention(
                 @NotNull M member,
                 @NotNull KeyConvention defaultConvention
         ) {
-            Class<?> declaringClass = member.getDeclaringClass();
-            Annotation[] a = member.getDeclaredAnnotations();
-            Annotation[] b = declaringClass.getDeclaredAnnotations();
-            final int al = a.length;
-            final int tl = al + b.length;
-
-            for (int i = 0; i < tl; i++) {
-                Annotation next = i < al ? a[i] : b[i - al];
+            Iterator<Annotation> annotations = memberAndDeclaringClassAnnotations(member).iterator();
+            while (annotations.hasNext()) {
+                Annotation next = annotations.next();
                 if (next instanceof Convention) return ((Convention) next).value();
                 Class<? extends Annotation> annotationType = next.annotationType();
                 if (!Convention.class.equals(annotationType.getDeclaringClass())) continue;
                 return resolveConventionHelperAnnotation(annotationType);
             }
-
             return defaultConvention;
         }
 
@@ -166,6 +244,18 @@ abstract class AbstractTableTypeModel<T> implements TableTypeModel<T> {
                 );
             }
             return value;
+        }
+
+        private static <M extends Member & AnnotatedElement> @NotNull Stream<Annotation> memberAndDeclaringClassAnnotations(
+                M member
+        ) {
+            Class<?> declaringClass = member.getDeclaringClass();
+            final Annotation[] a = member.getDeclaredAnnotations();
+            final Annotation[] b = declaringClass.getDeclaredAnnotations();
+            final int al = a.length;
+            final int tl = al + b.length;
+            return IntStream.range(0, tl)
+                    .mapToObj((int i) -> i < al ? a[i] : b[i - al]);
         }
 
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
@@ -22,10 +22,7 @@ import io.github.wasabithumb.jtoml.util.ParameterizedClass;
 import io.github.wasabithumb.recsup.RecordClass;
 import io.github.wasabithumb.recsup.RecordComponent;
 import io.github.wasabithumb.recsup.RecordSupport;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.UnknownNullability;
-import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.*;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -168,6 +165,46 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
 
     private static final class RecordComponentKey extends MemberKey<Method> {
 
+        private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = definePrimitiveDefaults(
+                Byte.TYPE, (byte) 0,
+                Byte.class, (byte) 0,
+                Short.TYPE, (short) 0,
+                Short.class, (short) 0,
+                Integer.TYPE, 0,
+                Integer.class, 0,
+                Long.TYPE, 0L,
+                Long.class, 0L,
+                Float.TYPE, 0f,
+                Float.class, 0f,
+                Double.TYPE, 0d,
+                Double.class, 0d,
+                Character.TYPE, (char) 0,
+                Character.class, (char) 0,
+                Boolean.TYPE, Boolean.FALSE,
+                Boolean.class, Boolean.FALSE
+        );
+
+        @SuppressWarnings("SameParameterValue")
+        private static Map<Class<?>, Object> definePrimitiveDefaults(
+               Object... entries
+        ) {
+            int len = entries.length;
+            assert (len & 1) == 0;
+            len >>= 1;
+
+            Map<Class<?>, Object> map = new HashMap<>((len * 4) / 3 + 1);
+            int head = 0;
+            for (int i = 0; i < len; i++) {
+                Class<?> key = (Class<?>) entries[head++];
+                Object value = entries[head++];
+                map.put(key, value);
+            }
+
+            return Collections.unmodifiableMap(map);
+        }
+
+        //
+
         private final RecordComponent component;
 
         RecordComponentKey(
@@ -176,6 +213,18 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
         ) {
             super(component.getAccessor(), defaultConvention);
             this.component = component;
+        }
+
+        //
+
+        @Override
+        protected Class<?> typeClassOf(Method member) {
+            return member.getReturnType();
+        }
+
+        @Override
+        protected @Nullable Object nonSpecificDefault(Class<?> type) {
+            return PRIMITIVE_DEFAULTS.get(type);
         }
 
     }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/RecordTableTypeModel.java
@@ -167,21 +167,13 @@ final class RecordTableTypeModel<T> extends AbstractTableTypeModel<T> {
 
         private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = definePrimitiveDefaults(
                 Byte.TYPE, (byte) 0,
-                Byte.class, (byte) 0,
                 Short.TYPE, (short) 0,
-                Short.class, (short) 0,
                 Integer.TYPE, 0,
-                Integer.class, 0,
                 Long.TYPE, 0L,
-                Long.class, 0L,
                 Float.TYPE, 0f,
-                Float.class, 0f,
                 Double.TYPE, 0d,
-                Double.class, 0d,
                 Character.TYPE, (char) 0,
-                Character.class, (char) 0,
-                Boolean.TYPE, Boolean.FALSE,
-                Boolean.class, Boolean.FALSE
+                Boolean.TYPE, Boolean.FALSE
         );
 
         @SuppressWarnings("SameParameterValue")

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/SerializableTableTypeModel.java
@@ -254,6 +254,18 @@ final class SerializableTableTypeModel<T extends TomlSerializable> extends Abstr
             super(field, defaultConvention);
         }
 
+        //
+
+        @Override
+        protected Class<?> typeClassOf(Field member) {
+            return member.getType();
+        }
+
+        @Override
+        protected @Nullable Object nonSpecificDefault(Class<?> type) {
+            return null;
+        }
+
     }
 
 }

--- a/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TableTypeModel.java
+++ b/serializer-reflect/src/main/java/io/github/wasabithumb/jtoml/serial/reflect/model/table/TableTypeModel.java
@@ -89,16 +89,16 @@ public interface TableTypeModel<T> extends TypeModel<T> {
 
     }
 
-    /**
-     * Exists to allow the original representation
-     * of the key to be retained by implementers
-     */
     interface Key {
 
         @NotNull TomlKey asTomlKey();
 
-        default boolean matches(@NotNull TomlKey other) {
-            return this.asTomlKey().equals(other);
+        default boolean isDefaulting() {
+            return false;
+        }
+
+        default @Nullable Object defaultValue() throws UnsupportedOperationException {
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingTestRoute.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingTestRoute.java
@@ -1,0 +1,43 @@
+package io.github.wasabithumb.jtoml.route.impl;
+
+import io.github.wasabithumb.jtoml.JToml;
+import io.github.wasabithumb.jtoml.route.Sentinel;
+import io.github.wasabithumb.jtoml.route.TestRoute;
+import io.github.wasabithumb.jtoml.serial.reflect.Defaulting;
+
+import static io.github.wasabithumb.jtoml.route.TestConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class DefaultingTestRoute implements TestRoute {
+
+    @Sentinel("defaulting.toml")
+    private Document document;
+
+    //
+
+    @Override
+    public String displayName() {
+        return "Defaulting";
+    }
+
+    @Override
+    public void execute(JToml instance) {
+        assertEquals(0xCAFEB015L, this.document.sanity);
+        assertNull(this.document.someString);
+        assertFalse(this.document.someBool);
+        assertEquals(0d, this.document.someFloat);
+        assertEquals(0, this.document.someInt);
+    }
+
+    //
+
+    @Defaulting
+    private record Document(
+            long sanity,
+            String someString,
+            boolean someBool,
+            double someFloat,
+            int someInt
+    ) { }
+
+}

--- a/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingTestRoute.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingTestRoute.java
@@ -3,15 +3,18 @@ package io.github.wasabithumb.jtoml.route.impl;
 import io.github.wasabithumb.jtoml.JToml;
 import io.github.wasabithumb.jtoml.route.Sentinel;
 import io.github.wasabithumb.jtoml.route.TestRoute;
+import io.github.wasabithumb.jtoml.serial.TomlSerializable;
 import io.github.wasabithumb.jtoml.serial.reflect.Defaulting;
 
-import static io.github.wasabithumb.jtoml.route.TestConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public final class DefaultingTestRoute implements TestRoute {
 
     @Sentinel("defaulting.toml")
-    private Document document;
+    private RecordDocument recordDocument;
+
+    @Sentinel("defaulting.toml")
+    private PojoDocument pojoDocument;
 
     //
 
@@ -22,22 +25,73 @@ public final class DefaultingTestRoute implements TestRoute {
 
     @Override
     public void execute(JToml instance) {
-        assertEquals(0xCAFEB015L, this.document.sanity);
-        assertNull(this.document.someString);
-        assertFalse(this.document.someBool);
-        assertEquals(0d, this.document.someFloat);
-        assertEquals(0, this.document.someInt);
+        checkDocument(this.recordDocument);
+        checkDocument(this.pojoDocument);
+    }
+
+    private void checkDocument(Document document) {
+        assertEquals(0xCAFEB015L, document.sanity());
+        assertNull(document.someString());
+        assertFalse(document.someBool());
+        assertEquals(0d, document.someFloat());
+        assertEquals(0, document.someInt());
     }
 
     //
 
+    private interface Document {
+        long sanity();
+        String someString();
+        boolean someBool();
+        double someFloat();
+        int someInt();
+    }
+
     @Defaulting
-    private record Document(
+    private record RecordDocument(
             long sanity,
             String someString,
             boolean someBool,
             double someFloat,
             int someInt
-    ) { }
+    ) implements Document { }
+
+    @Defaulting
+    private static final class PojoDocument implements TomlSerializable, Document {
+
+        private long sanity;
+        private String someString;
+        private boolean someBool;
+        private double someFloat;
+        private int someInt;
+
+        //
+
+        @Override
+        public long sanity() {
+            return this.sanity;
+        }
+
+        @Override
+        public String someString() {
+            return this.someString;
+        }
+
+        @Override
+        public boolean someBool() {
+            return this.someBool;
+        }
+
+        @Override
+        public double someFloat() {
+            return this.someFloat;
+        }
+
+        @Override
+        public int someInt() {
+            return this.someInt;
+        }
+
+    }
 
 }

--- a/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingWithValueTestRoute.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/route/impl/DefaultingWithValueTestRoute.java
@@ -1,0 +1,42 @@
+package io.github.wasabithumb.jtoml.route.impl;
+
+import io.github.wasabithumb.jtoml.JToml;
+import io.github.wasabithumb.jtoml.route.Sentinel;
+import io.github.wasabithumb.jtoml.route.TestRoute;
+import io.github.wasabithumb.jtoml.serial.reflect.Defaulting;
+
+import static io.github.wasabithumb.jtoml.route.TestConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class DefaultingWithValueTestRoute implements TestRoute {
+
+    @Sentinel("defaulting.toml")
+    private Document document;
+
+    //
+
+    @Override
+    public String displayName() {
+        return "Defaulting with Value";
+    }
+
+    @Override
+    public void execute(JToml instance) {
+        assertEquals(0xCAFEB015L, this.document.sanity);
+        assertEquals(LOREM_IPSUM, this.document.someString);
+        assertTrue(this.document.someBool);
+        assertEquals(PI, this.document.someFloat);
+        assertEquals(MEANING_OF_LIFE, this.document.someInt);
+    }
+
+    //
+
+    private record Document(
+            long sanity,
+            @Defaulting.ToString(LOREM_IPSUM) String someString,
+            @Defaulting.ToBool(true) boolean someBool,
+            @Defaulting.ToFloat(PI) double someFloat,
+            @Defaulting.ToInt(MEANING_OF_LIFE) int someInt
+    ) { }
+
+}

--- a/src/test/resources/sentinel/defaulting.toml
+++ b/src/test/resources/sentinel/defaulting.toml
@@ -1,0 +1,2 @@
+sanity = 0xCAFEB015
+# other fields intentionally not declared


### PR DESCRIPTION
Resolves #63, adds ``@Defaulting`` and variants to allow optional fields/components. The base ``@Defaulting`` works as expected, initializing objects to ``null`` and primitives to the "zero" value. For records this means explicitly injecting the value into the primary constructor, and for POJOs this means not touching the field and leaving it uninitialized. 

Also included in this PR is ``@Defaulting.ToString``, ``@Defaulting.ToInt``, ``@Defaulting.ToFloat`` and ``@Defaulting.ToBool``. These are named owing to the TOML primitive data types- while there is no ``@Defaulting.ToChar`` for example, you can use ``@Defaulting.ToInt`` on a ``char`` or ``Character`` field.