### PR TITLE
Update test suite to v2.2.x

### DIFF
--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTemporalTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTemporalTomlPrimitive.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Xavier Pedraza
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.wasabithumb.jtoml.value.primitive;
 
 import io.github.wasabithumb.jtoml.comment.Comments;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTemporalTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTemporalTomlPrimitive.java
@@ -1,0 +1,96 @@
+package io.github.wasabithumb.jtoml.value.primitive;
+
+import io.github.wasabithumb.jtoml.comment.Comments;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.Temporal;
+
+@ApiStatus.Internal
+abstract class AbstractTemporalTomlPrimitive<T extends Serializable & Temporal>
+        extends AbstractTomlPrimitive<T>
+{
+
+    private static void writeDigit(@NotNull StringBuilder sb, @Range(from=0, to=9) int d) {
+        sb.append((char) (d + '0'));
+    }
+
+    protected static void writeDate(@NotNull StringBuilder sb, @NotNull LocalDate date) {
+        int year = date.getYear();
+        if (year > 9999) {
+            sb.append(year);
+        } else {
+            writeDigit(sb, year / 1000);
+            writeDigit(sb, (year % 1000) / 100);
+            writeDigit(sb, (year % 100) / 10);
+            writeDigit(sb, year % 10);
+        }
+        sb.append('-');
+
+        int month = date.getMonthValue();
+        writeDigit(sb, month / 10);
+        writeDigit(sb, month % 10);
+        sb.append('-');
+
+        int day = date.getDayOfMonth();
+        writeDigit(sb, day / 10);
+        writeDigit(sb, day % 10);
+    }
+
+    protected static void writeHourMinute(@NotNull StringBuilder sb, int hour, int minute) {
+        writeDigit(sb, hour / 10);
+        writeDigit(sb, hour % 10);
+        sb.append(':');
+        writeDigit(sb, minute / 10);
+        writeDigit(sb, minute % 10);
+    }
+
+    protected static void writeTime(
+            @NotNull StringBuilder sb,
+            @NotNull LocalTime time,
+            @Range(from = 1, to = 9) int minNanos
+    ) {
+        writeHourMinute(sb, time.getHour(), time.getMinute());
+        sb.append(':');
+
+        int second = time.getSecond();
+        writeDigit(sb, second / 10);
+        writeDigit(sb, second % 10);
+
+        int nano = time.getNano();
+        if (nano != 0) {
+            char[] buf = new char[9];
+
+            for (int i=0; i < 9; i++) {
+                buf[8 - i] = (char) ((nano % 10) + '0');
+                nano /= 10;
+            }
+
+            int end = 9;
+            while (end > minNanos && buf[end - 1] == '0') {
+                end--;
+            }
+
+            sb.append('.');
+
+            for (int i=0; i < end; i++) {
+                sb.append(buf[i]);
+            }
+        }
+    }
+
+    //
+
+    /** @implNote Modified by UnsafePrimitives */
+    @Range(from = 1, to = 9) int minNanoResolution;
+
+    protected AbstractTemporalTomlPrimitive(@NotNull Comments comments) {
+        super(comments);
+        this.minNanoResolution = 1;
+    }
+
+}

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/AbstractTomlPrimitive.java
@@ -19,81 +19,12 @@ package io.github.wasabithumb.jtoml.value.primitive;
 import io.github.wasabithumb.jtoml.comment.Comments;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Range;
 
 import java.io.Serializable;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.ZoneOffset;
 
 @ApiStatus.Internal
 abstract class AbstractTomlPrimitive<T extends Serializable> implements TomlPrimitive {
-
-    protected static void writeDigit(@NotNull StringBuilder sb, @Range(from=0, to=9) int d) {
-        sb.append((char) (d + '0'));
-    }
-
-    protected static void writeDate(@NotNull StringBuilder sb, @NotNull LocalDate date) {
-        int year = date.getYear();
-        if (year > 9999) {
-            sb.append(year);
-        } else {
-            writeDigit(sb, year / 1000);
-            writeDigit(sb, (year % 1000) / 100);
-            writeDigit(sb, (year % 100) / 10);
-            writeDigit(sb, year % 10);
-        }
-        sb.append('-');
-
-        int month = date.getMonthValue();
-        writeDigit(sb, month / 10);
-        writeDigit(sb, month % 10);
-        sb.append('-');
-
-        int day = date.getDayOfMonth();
-        writeDigit(sb, day / 10);
-        writeDigit(sb, day % 10);
-    }
-
-    protected static void writeHourMinute(@NotNull StringBuilder sb, int hour, int minute) {
-        writeDigit(sb, hour / 10);
-        writeDigit(sb, hour % 10);
-        sb.append(':');
-        writeDigit(sb, minute / 10);
-        writeDigit(sb, minute % 10);
-    }
-
-    protected static void writeTime(@NotNull StringBuilder sb, @NotNull LocalTime time) {
-        writeHourMinute(sb, time.getHour(), time.getMinute());
-        sb.append(':');
-
-        int second = time.getSecond();
-        writeDigit(sb, second / 10);
-        writeDigit(sb, second % 10);
-
-        int nano = time.getNano();
-        if (nano != 0) {
-            char[] buf = new char[9];
-
-            for (int i=0; i < 9; i++) {
-                buf[8 - i] = (char) ((nano % 10) + '0');
-                nano /= 10;
-            }
-
-            int end = 9;
-            while (end > 3 && buf[end - 1] == '0') {
-                end--;
-            }
-
-            sb.append('.');
-
-            for (int i=0; i < end; i++) {
-                sb.append(buf[i]);
-            }
-        }
-    }
-
-    //
 
     protected final long creationTime;
     protected final Comments comments;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTimeTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTimeTomlPrimitive.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.*;
 
 @ApiStatus.Internal
-final class LocalDateTimeTomlPrimitive extends AbstractTomlPrimitive<LocalDateTime> {
+final class LocalDateTimeTomlPrimitive extends AbstractTemporalTomlPrimitive<LocalDateTime> {
 
     private final LocalDateTime value;
     private final ZoneOffset offset;
@@ -69,7 +69,7 @@ final class LocalDateTimeTomlPrimitive extends AbstractTomlPrimitive<LocalDateTi
         StringBuilder sb = new StringBuilder();
         writeDate(sb, this.value.toLocalDate());
         sb.append('T');
-        writeTime(sb, this.value.toLocalTime());
+        writeTime(sb, this.value.toLocalTime(), this.minNanoResolution);
         return sb.toString();
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalDateTomlPrimitive.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.*;
 
 @ApiStatus.Internal
-final class LocalDateTomlPrimitive extends AbstractTomlPrimitive<LocalDate> {
+final class LocalDateTomlPrimitive extends AbstractTemporalTomlPrimitive<LocalDate> {
 
     private final LocalDate value;
     private final ZoneOffset offset;

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalTimeTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/LocalTimeTomlPrimitive.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.*;
 
 @ApiStatus.Internal
-final class LocalTimeTomlPrimitive extends AbstractTomlPrimitive<LocalTime> {
+final class LocalTimeTomlPrimitive extends AbstractTemporalTomlPrimitive<LocalTime> {
 
     private final LocalTime value;
     private final ZoneOffset offset;
@@ -65,7 +65,7 @@ final class LocalTimeTomlPrimitive extends AbstractTomlPrimitive<LocalTime> {
     @Override
     public @NotNull String asString() {
         StringBuilder sb = new StringBuilder();
-        writeTime(sb, this.value);
+        writeTime(sb, this.value, this.minNanoResolution);
         return sb.toString();
     }
 

--- a/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/OffsetDateTimeTomlPrimitive.java
+++ b/api/src/main/java/io/github/wasabithumb/jtoml/value/primitive/OffsetDateTimeTomlPrimitive.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.*;
 
 @ApiStatus.Internal
-final class OffsetDateTimeTomlPrimitive extends AbstractTomlPrimitive<OffsetDateTime> {
+final class OffsetDateTimeTomlPrimitive extends AbstractTemporalTomlPrimitive<OffsetDateTime> {
 
     private final OffsetDateTime value;
 
@@ -61,7 +61,7 @@ final class OffsetDateTimeTomlPrimitive extends AbstractTomlPrimitive<OffsetDate
 
         writeDate(sb, this.value.toLocalDate());
         sb.append('T');
-        writeTime(sb, this.value.toLocalTime());
+        writeTime(sb, this.value.toLocalTime(), this.minNanoResolution);
 
         int sec = this.value.getOffset().getTotalSeconds();
         if (sec == 0) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import tasks.FetchTestsTask
 
 allprojects {
     apply(plugin = "java-library")
-
     group = "io.github.wasabithumb"
     version = "1.5.2"
 }
@@ -73,7 +72,8 @@ dependencies {
 }
 
 tasks.register<FetchTestsTask>("fetchTests") {
-    outputs.upToDateWhen { false }
+    description = "Ensures that the official test suite is cloned and checked out to the correct tag"
+    versionPattern = "^v2\\.2\\..*$".toRegex() // v2.2.x
 }
 
 tasks.processTestResources {

--- a/buildSrc/src/main/kotlin/tasks/FetchTestsTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/FetchTestsTask.kt
@@ -1,53 +1,64 @@
 package tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.lang.IllegalStateException
 
 import java.nio.file.Files
 import java.nio.file.Path
 
+@CacheableTask
 abstract class FetchTestsTask : DefaultTask() {
 
-    private val workDir: Path
-    private val gitMetaDir: Path
-    private val outDir: Path
+    @get:Input
+    abstract val versionPattern: Property<Regex>
+
+    @get:Internal
+    protected abstract val workDir: DirectoryProperty
+
+    @get:OutputDirectory
+    protected abstract val outDir: DirectoryProperty
 
     init {
-        val workDir = this.temporaryDir.toPath()
-        val gitMetaDir = workDir.resolve(".git")
-        val outDir = workDir.resolve("tests")
-
-        this.workDir = workDir
-        this.gitMetaDir = gitMetaDir
-        this.outDir = outDir
-        this.outputs.dir(outDir)
+        val work = project.layout.buildDirectory.dir(this.name)
+        this.versionPattern.convention(Regex("^v2\\..*"))
+        this.workDir.convention(work)
+        this.outDir.convention(work.map { it.dir("tests") })
     }
 
     //
 
     @TaskAction
     fun execute() {
-        if (!Files.exists(this.gitMetaDir)) {
+        val versionPattern = this.versionPattern.get()
+        val workDir = this.workDir.get().asFile.toPath()
+        val gitMetaDir = workDir.resolve(".git")
+
+        if (!Files.exists(gitMetaDir)) {
             this.logger.lifecycle("Cloning toml-lang/toml-test")
-            this.runGit(this.workDir, "init")
-            this.runGit(this.workDir, "remote", "add", "origin", "https://github.com/toml-lang/toml-test")
-            this.runGit(this.workDir, "fetch", "origin")
-            this.runGit(this.workDir, "checkout", "origin/main", "-ft")
+            this.runGit(workDir, "init")
+            this.runGit(workDir, "remote", "add", "origin", "https://github.com/toml-lang/toml-test")
+            this.runGit(workDir, "fetch", "origin")
+            this.runGit(workDir, "checkout", "origin/main", "-ft")
         } else {
-            // this.logger.lifecycle("Checking for test suite updates")
-            // this.runGit(repo, "fetch", "origin")
+            this.runGit(workDir, "fetch", "origin")
         }
 
-        val currentSha = runGit(this.workDir, "rev-parse", "HEAD").first()
-        val targetTag = runGit(this.workDir, "tag", "--sort=v:refname").last { it.startsWith("v1") }
-        val targetSha = runGit(this.workDir, "rev-list", "-n", "1", targetTag).first()
+        val currentSha = runGit(workDir, "rev-parse", "HEAD").first()
+        val targetTag = runGit(workDir, "tag", "--sort=v:refname").last { versionPattern.matches(it) }
+        val targetSha = runGit(workDir, "rev-list", "-n", "1", targetTag).first()
 
         if (currentSha == targetSha) {
             this.logger.lifecycle("Test suite is up-to-date")
         } else {
             this.logger.lifecycle("Changing test suite version to $targetTag")
-            this.runGit(this.workDir, "checkout", targetSha)
+            this.runGit(workDir, "checkout", targetSha)
         }
     }
 

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
@@ -601,7 +601,10 @@ public class ExpressionReader implements Closeable {
         if (len < 5) {
             truncated = true;
         } else if (str.charAt(2) == ':') { // Local Time
-            return TomlPrimitive.of(this.parsePartialTime(str, 0, len), this.options.get(JTomlOption.TIME_ZONE));
+            PartialTime pt = this.parsePartialTime(str, 0, len);
+            TomlPrimitive ret = TomlPrimitive.of(pt.time, this.options.get(JTomlOption.TIME_ZONE));
+            UnsafePrimitives.setTemporalMinNanoResolution(ret, pt.nanoPrecision);
+            return ret;
         } else if (len < 8) {
             truncated = true;
         }
@@ -641,10 +644,13 @@ public class ExpressionReader implements Closeable {
         }
 
         if (whereOffset == -1) {                                                        // Local Date-Time
-            LocalTime time = this.parsePartialTime(str, 11, len - 11);
-            return TomlPrimitive.of(LocalDateTime.of(date, time), this.options.get(JTomlOption.TIME_ZONE));
+            PartialTime pt = this.parsePartialTime(str, 11, len - 11);
+            TomlPrimitive ret = TomlPrimitive.of(LocalDateTime.of(date, pt.time), this.options.get(JTomlOption.TIME_ZONE));
+            UnsafePrimitives.setTemporalMinNanoResolution(ret, pt.nanoPrecision);
+            return ret;
         } else {                                                                        // Offset Date-Time
-            LocalTime time = this.parsePartialTime(str, 11, whereOffset - 11);
+            PartialTime pt = this.parsePartialTime(str, 11, whereOffset - 11);
+            LocalTime time = pt.time;
             LocalDateTime dateTime = LocalDateTime.of(date, time);
             ZoneOffset offset;
             if (numOffset) {
@@ -666,11 +672,13 @@ public class ExpressionReader implements Closeable {
             } else {
                 offset = ZoneOffset.UTC;
             }
-            return TomlPrimitive.of(dateTime.atOffset(offset));
+            TomlPrimitive ret = TomlPrimitive.of(dateTime.atOffset(offset));
+            UnsafePrimitives.setTemporalMinNanoResolution(ret, pt.nanoPrecision);
+            return ret;
         }
     }
 
-    private @NotNull LocalTime parsePartialTime(@NotNull CharSequence str, int off, int len) throws TomlException {
+    private @NotNull PartialTime parsePartialTime(@NotNull CharSequence str, int off, int len) throws TomlException {
         // v1.1.0 - support datetimes without seconds
         boolean ignoreSeconds = false;
         if (len == 5 && this.options.get(JTomlOption.COMPLIANCE).isAtLeast(1, 1)) {
@@ -690,6 +698,7 @@ public class ExpressionReader implements Closeable {
         if (second < 0 || second > 59) this.in.raise("Second out of range (got " + second + ")");
 
         int nanos = 0;
+        int nanoPrecision = 1;
         if (len > 8) {
             char c = str.charAt(off + 8);
             if (c != '.') this.in.raise("Expected decimal point");
@@ -697,6 +706,7 @@ public class ExpressionReader implements Closeable {
             int nd = len - 9;
             if (nd <= 9) {
                 nanos = this.parseNDigits(str, off + 9, nd);
+                nanoPrecision = nd;
                 switch (nd) {
                     case 1: nanos *= 100000000; break;
                     case 2: nanos *= 10000000; break;
@@ -709,6 +719,7 @@ public class ExpressionReader implements Closeable {
                 }
             } else {
                 nanos = this.parseNDigits(str, off + 9, 9);
+                nanoPrecision = 9;
                 for (int i=18; i < len; i++) {
                     c = str.charAt(off + i);
                     if (c < '0' || c > '9') this.in.raise("Expected digit");
@@ -716,7 +727,10 @@ public class ExpressionReader implements Closeable {
             }
         }
 
-        return LocalTime.of(hour, minute, second, nanos);
+        return new PartialTime(
+                LocalTime.of(hour, minute, second, nanos),
+                nanoPrecision
+        );
     }
 
     private int parseNDigits(@NotNull CharSequence str, int off, int len) throws TomlException {
@@ -1159,6 +1173,18 @@ public class ExpressionReader implements Closeable {
         ArrayControl(char character, @UnknownNullability List<String> comments) {
             this.character = character;
             this.comments = comments;
+        }
+
+    }
+
+    private static final class PartialTime {
+
+        final LocalTime time;
+        final int nanoPrecision;
+
+        PartialTime(LocalTime time, int nanoPrecision) {
+            this.time = time;
+            this.nanoPrecision = nanoPrecision;
         }
 
     }

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/io/ExpressionReader.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import java.io.Closeable;
 import java.time.*;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -986,25 +987,25 @@ public class ExpressionReader implements Closeable {
     }
 
     private @NotNull TomlTable readInlineTable() throws TomlException {
+        List<String> commentStack = new LinkedList<>();
         TomlTable ret = TomlTable.create();
+        TomlValue lastValue = null;
         boolean expectComma = false;
         int ctrl;
         char c;
 
         while (true) {
-            ctrl = this.readInlineTableControl();
+            ctrl = this.readInlineTableControl(commentStack);
             if (ctrl == -1) this.in.raise("Unclosed inline table");
             c = (char) ctrl;
-            if (c == '}') return ret;
+            if (c == '}') break;
             if (expectComma) {
                 if (c != ',') this.in.raise("Expected inline table separator or closing char");
-                ctrl = this.readInlineTableControl();
+                ctrl = this.readInlineTableControl(commentStack);
                 if (ctrl == -1) this.in.raise("Unclosed inline table");
                 if (ctrl == '}') {
                     // v1.1.0 - allow trailing commas
-                    if (this.options.get(JTomlOption.COMPLIANCE).isAtLeast(1, 1)) {
-                        return ret;
-                    }
+                    if (this.options.get(JTomlOption.COMPLIANCE).isAtLeast(1, 1)) break;
                     this.in.raise("Disallowed trailing comma in inline table");
                 }
                 c = (char) ctrl;
@@ -1019,12 +1020,29 @@ public class ExpressionReader implements Closeable {
                 if (TomlValueFlags.isConstant(existing))
                     this.in.raise(key + " conflicts with previously defined key " + partialKey + " in inline table");
             }
-            ctrl = this.readInlineTableControl();
+            ctrl = this.readInlineTableControl(commentStack);
             if (ctrl == -1) this.in.raise("Expected value, got EOF");
             TomlValue value = this.readValue(ctrl);
+            for (String comment : commentStack) value.comments().addPre(comment);
+            commentStack.clear();
             ret.put(key, TomlValueFlags.setConstant(value, true));
+            lastValue = value;
             expectComma = true;
         }
+
+        if (!commentStack.isEmpty()) {
+            if (lastValue != null) {
+                for (String comment : commentStack)
+                    lastValue.comments().addPost(comment);
+            }
+            // TODO: Comments are getting THROWN OUT
+            // when parsing multiline inline tables
+            // with no key-values in them. Retaining
+            // these comments would require rethinking
+            // the entire comments API ;(
+        }
+
+        return ret;
     }
 
     private @NotNull TomlArray readArray() throws TomlException {
@@ -1108,7 +1126,7 @@ public class ExpressionReader implements Closeable {
     }
 
     /** Skip specific to inline tables */
-    private int readInlineTableControl() throws TomlException {
+    private int readInlineTableControl(Collection<? super String> comments) throws TomlException {
         if (this.options.get(JTomlOption.COMPLIANCE).isAtLeast(1, 1)) {
             // v1.1.0 - support newlines in inline tables
             char c;
@@ -1117,6 +1135,10 @@ public class ExpressionReader implements Closeable {
                 if (c == '\r') {
                     c = this.in.nextChar();
                     if (c != '\n') this.in.raise("Expected LF after CR within inline table");
+                    continue;
+                }
+                if (c == '#') {
+                    comments.add(this.in.finishExpression(true));
                     continue;
                 }
                 if (c != '\n') return c;

--- a/internals/src/main/java/io/github/wasabithumb/jtoml/value/UnsafePrimitives.java
+++ b/internals/src/main/java/io/github/wasabithumb/jtoml/value/UnsafePrimitives.java
@@ -20,8 +20,10 @@ import io.github.wasabithumb.jtoml.value.primitive.TomlPrimitive;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Range;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,18 +32,26 @@ import java.util.logging.Logger;
 public final class UnsafePrimitives {
 
     private static final Constructor<?> FLOAT_WITH_CHARS;
+    private static final Class<?> TEMPORAL_CLASS;
+    private static final Field TEMPORAL_MIN_NANO_RESOLUTION;
     static {
-        Class<?> cls;
-        Constructor<?> con = null;
+        Constructor<?> floatWithChars = null;
+        Class<?> temporalClass = null;
+        Field temporalMinNanoResolution = null;
         try {
-            cls = Class.forName("io.github.wasabithumb.jtoml.value.primitive.FloatTomlPrimitive");
-            con = cls.getDeclaredConstructor(Double.TYPE, String.class);
-            con.setAccessible(true);
-        } catch (ReflectiveOperationException | SecurityException e) {
+            Class<?> clsFloatTomlPrimitive = Class.forName("io.github.wasabithumb.jtoml.value.primitive.FloatTomlPrimitive");
+            floatWithChars = clsFloatTomlPrimitive.getDeclaredConstructor(Double.TYPE, String.class);
+            floatWithChars.setAccessible(true);
+            temporalClass = Class.forName("io.github.wasabithumb.jtoml.value.primitive.AbstractTemporalTomlPrimitive");
+            temporalMinNanoResolution = temporalClass.getDeclaredField("minNanoResolution");
+            temporalMinNanoResolution.setAccessible(true);
+        } catch (Exception e) {
             Logger.getLogger("jtoml")
-                    .log(Level.WARNING, "Failed to access float constructor (please report this)", e);
+                    .log(Level.WARNING, "Failed to access internals (please report this)", e);
         }
-        FLOAT_WITH_CHARS = con;
+        FLOAT_WITH_CHARS = floatWithChars;
+        TEMPORAL_CLASS = temporalClass;
+        TEMPORAL_MIN_NANO_RESOLUTION = temporalMinNanoResolution;
     }
 
     //
@@ -52,15 +62,32 @@ public final class UnsafePrimitives {
         TomlPrimitive ret;
         try {
             ret = (TomlPrimitive) FLOAT_WITH_CHARS.newInstance(v, chars);
-        } catch (InvocationTargetException | ExceptionInInitializerError e) {
+        } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause == null) cause = e;
-            if (cause instanceof RuntimeException) throw ((RuntimeException) cause);
-            throw new AssertionError("Unexpected error in constructor/initializer", e);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("Unexpected reflection error", e);
+            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+            throw new IllegalStateException("Primitive constructor raised a checked exception", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unexpected reflection error", e);
         }
         return ret;
+    }
+
+    @Contract(mutates = "param1")
+    public static void setTemporalMinNanoResolution(
+            TomlPrimitive target,
+            @Range(from = 1, to = 9) int minNanoResolution
+    ) {
+        if (TEMPORAL_CLASS == null ||
+                TEMPORAL_MIN_NANO_RESOLUTION == null ||
+                !TEMPORAL_CLASS.isInstance(target)
+        ) return;
+
+        try {
+            TEMPORAL_MIN_NANO_RESOLUTION.setInt(target, minNanoResolution);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unexpected reflection error", e);
+        }
     }
 
     //

--- a/src/test/java17/io/github/wasabithumb/jtoml/spec/ValidTestSpec.java
+++ b/src/test/java17/io/github/wasabithumb/jtoml/spec/ValidTestSpec.java
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -147,13 +150,19 @@ final class ValidTestSpec extends AbstractTestSpec {
             assertTrue(primitive.isBoolean(), "Expected " + descriptor + " to be a boolean");
         } else if ("datetime".equals(vType)) {
             assertTrue(primitive.isOffsetDateTime(), "Expected " + descriptor + " to be an offset date-time");
+            assertEquals(OffsetDateTime.parse(vValue), primitive.asOffsetDateTime());
+            return;
         } else if ("datetime-local".equals(vType)) {
             assertTrue(primitive.isLocalDateTime(), "Expected " + descriptor + " to be a local date-time");
+            assertEquals(LocalDateTime.parse(vValue), primitive.asLocalDateTime());
+            return;
         } else if ("date-local".equals(vType)) {
             assertTrue(primitive.isLocalDate(), "Expected " + descriptor + " to be a local date");
         } else {
             assertEquals("time-local", vType);
-            assertTrue(primitive.isLocalTime(), "Expected " + descriptor + " tto be a local time");
+            assertTrue(primitive.isLocalTime(), "Expected " + descriptor + " to be a local time");
+            assertEquals(LocalTime.parse(vValue), primitive.asLocalTime());
+            return;
         }
 
         assertEquals(vValue, primitive.asString());


### PR DESCRIPTION
This draft PR is the beginning of a motion to improve test integrity. The test suite version has been locked to 1.x.x for a while (originally this was motivated by 2.0.0 removing files we relied upon, this was fixed in 2.1.0). Since the test suite has been updating independently of this library for a few months, there are now 4/895 test cases that do not pass. These need to be resolved before merging:

- [x] ``valid/inline-table/newline-comment`` fails with ``TomlLocalParseException: Invalid newline within key @ 5:0``
- [x] ``valid/spec-1.1.0/common-27`` fails with ``AssertionFailedError: expected: <1979-05-27T00:32:00.5-07:00> but was: <1979-05-27T00:32:00.500-07:00>``
- [x] ``valid/spec-1.1.0/common-30`` fails with ``AssertionFailedError: expected: <1979-05-27T07:32:00.5> but was: <1979-05-27T07:32:00.500>``
- [x] ``valid/spec-1.1.0/common-33`` fails with ``AssertionFailedError: expected: <00:32:00.5> but was: <00:32:00.500>``

I've also taken the opportunity to fix the ``buildSrc`` a bit to better observe standard Gradle conventions. This should help the ``fetchTests`` task work better with Gradle's caches, obsolete the need for ``outputs.upToDateWhen { false }``, and allow us to restore the ``git fetch origin`` functionality for discovering new tags without worries of slowing down the build.